### PR TITLE
chore: update  libvirt-daemon-system depends

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libvirt (9.8.0-1deepin1) UNRELEunstableASED; urgency=medium
+
+  * Modify the polkitd version of libvirt daemon system dependency
+
+ -- bluesky <chenchongbiao@deepin.org>  Wed, 22 Nov 2023 10:52:24 +0800
+
 libvirt (9.8.0-1) unstable; urgency=medium
 
   [ Pino Toscano ]

--- a/debian/control
+++ b/debian/control
@@ -339,7 +339,7 @@ Depends:
  libvirt0 (<< ${source:Version}.1~),
  libvirt0 (>= ${source:Version}),
  logrotate,
- polkitd (>= 121+compat0.1-2) [linux-any],
+ polkitd (>= 0.105.11.2-1+dde) [linux-any],
  ${misc:Depends},
 Recommends:
  dmidecode,


### PR DESCRIPTION
修改 libvirt-daemon-system  依赖的 polkitd 的最低版本为 0.105.11.2-1+dde，目前 libvirt 项目被添加入过多 patch ，无法和上游项目同步，后续方案需要讨论。

Issue: https://github.com/linuxdeepin/developer-center/issues/6220
Log: update depends