### PR TITLE
Hygon: Support reuse ASID and secret injection for Hygon CSV

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libvirt (10.7.0-3deepin1) unstable; urgency=medium
+
+  * Support reuse asid and secret injection for Hygon CSV
+
+ -- hanliyang <hanliyang@hygon.cn>  Fri, 15 Nov 2024 11:49:11 +0800
+
 libvirt (10.7.0-3) unstable; urgency=medium
 
   * [70a5d8d] patches: Add backport/apparmor-Don-t-check-for[...]

--- a/debian/patches/deepin/0001-conf-qemu-add-libvirt-support-reuse-id-for-hygon-CSV.patch
+++ b/debian/patches/deepin/0001-conf-qemu-add-libvirt-support-reuse-id-for-hygon-CSV.patch
@@ -1,0 +1,89 @@
+From cf8e84ea441c402eb8ed07baaa54aae2ccd9f80e Mon Sep 17 00:00:00 2001
+From: panpingsheng <panpingsheng@hygon.cn>
+Date: Fri, 8 Sep 2023 15:04:44 +0800
+Subject: [PATCH 1/2] conf: qemu: add libvirt support reuse id for hygon CSV
+
+csv xml format:
+<launchSecurity type='sev'>
+	<policy>0x0081</policy>
+	<cbitpos>47</cbitpos>
+	<reducedPhysBits>5</reducedPhysBits>
+	<userid>usertest</userid>
+</launchSecurity>
+
+Signed-off-by: panpingsheng <panpingsheng@hygon.cn>
+Signed-off-by: Xin Jiang <jiangxin@hygon.cn>
+Signed-off-by: hanliyang <hanliyang@hygon.cn>
+---
+ src/conf/domain_conf.c  | 5 +++++
+ src/conf/domain_conf.h  | 1 +
+ src/qemu/qemu_command.c | 4 ++++
+ 3 files changed, 10 insertions(+)
+
+diff --git a/src/conf/domain_conf.c b/src/conf/domain_conf.c
+index 5f0b35be..e32b16d5 100644
+--- a/src/conf/domain_conf.c
++++ b/src/conf/domain_conf.c
+@@ -3858,6 +3858,7 @@ virDomainSecDefFree(virDomainSecDef *def)
+     case VIR_DOMAIN_LAUNCH_SECURITY_SEV:
+         g_free(def->data.sev.dh_cert);
+         g_free(def->data.sev.session);
++        g_free(def->data.sev.user_id);
+         break;
+     case VIR_DOMAIN_LAUNCH_SECURITY_SEV_SNP:
+         g_free(def->data.sev_snp.guest_visible_workarounds);
+@@ -13745,6 +13746,7 @@ virDomainSEVDefParseXML(virDomainSEVDef *def,
+ 
+     def->dh_cert = virXPathString("string(./dhCert)", ctxt);
+     def->session = virXPathString("string(./session)", ctxt);
++    def->user_id = virXPathString("string(./userid)", ctxt);
+ 
+     return 0;
+ }
+@@ -26906,6 +26908,9 @@ virDomainSEVDefFormat(virBuffer *attrBuf,
+     virBufferAsprintf(childBuf, "<policy>0x%04x</policy>\n", def->policy);
+     virBufferEscapeString(childBuf, "<dhCert>%s</dhCert>\n", def->dh_cert);
+     virBufferEscapeString(childBuf, "<session>%s</session>\n", def->session);
++
++    if (def->user_id)
++        virBufferEscapeString(childBuf, "<userid>%s</userid>\n", def->user_id);
+ }
+ 
+ 
+diff --git a/src/conf/domain_conf.h b/src/conf/domain_conf.h
+index 659299bd..6de7a754 100644
+--- a/src/conf/domain_conf.h
++++ b/src/conf/domain_conf.h
+@@ -2889,6 +2889,7 @@ struct _virDomainSEVDef {
+     char *dh_cert;
+     char *session;
+     unsigned int policy;
++    char *user_id;
+ };
+ 
+ 
+diff --git a/src/qemu/qemu_command.c b/src/qemu/qemu_command.c
+index 1b992d8e..cc550a49 100644
+--- a/src/qemu/qemu_command.c
++++ b/src/qemu/qemu_command.c
+@@ -9755,6 +9755,9 @@ qemuBuildSEVCommandLine(virDomainObj *vm, virCommand *cmd,
+     VIR_DEBUG("policy=0x%x cbitpos=%d reduced_phys_bits=%d",
+               sev->policy, sev->common.cbitpos, sev->common.reduced_phys_bits);
+ 
++    if (sev->user_id)
++        VIR_DEBUG("user_id=%s", sev->user_id);
++
+     if (sev->dh_cert)
+         dhpath = g_strdup_printf("%s/dh_cert.base64", priv->libDir);
+ 
+@@ -9768,6 +9771,7 @@ qemuBuildSEVCommandLine(virDomainObj *vm, virCommand *cmd,
+                                      "S:dh-cert-file", dhpath,
+                                      "S:session-file", sessionpath,
+                                      "T:kernel-hashes", sev->common.kernel_hashes,
++                                     "S:user-id", sev->user_id,
+                                      NULL) < 0)
+         return -1;
+ 
+-- 
+2.25.1
+

--- a/debian/patches/deepin/0002-conf-qemu-support-provide-inject-secret-for-Hygon-CS.patch
+++ b/debian/patches/deepin/0002-conf-qemu-support-provide-inject-secret-for-Hygon-CS.patch
@@ -1,0 +1,129 @@
+From a69deb39b5338a06d59ae89b993d2689b13ce350 Mon Sep 17 00:00:00 2001
+From: hanliyang <hanliyang@hygon.cn>
+Date: Wed, 13 Nov 2024 16:12:57 +0800
+Subject: [PATCH 2/2] conf: qemu: support provide inject secret for Hygon CSV
+
+csv xml format:
+<launchSecurity type='sev'>
+  <policy>0x0001</policy>
+  <cbitpos>47</cbitpos>
+  <reducePhysBits>5</reducedPhysBits>
+  <dhCert>U2FsdGVkX1+rW6B/JbYqNA==</dhCert>
+  <session>5aeG4mH2E/OqN1a3uT8hfg==</session>
+  <secretHeader>gW3E30rG/I3L1nD/YfG+DA==</secretHeader>
+  <secret>zP1oY9W7ZcPFtL0QeN11vQ==</secret>
+</launchSecurity>
+
+Signed-off-by: hanliyang <hanliyang@hygon.cn>
+---
+ src/conf/domain_conf.c  |  8 ++++++++
+ src/conf/domain_conf.h  |  2 ++
+ src/qemu/qemu_command.c | 10 ++++++++++
+ src/qemu/qemu_process.c | 10 ++++++++++
+ 4 files changed, 30 insertions(+)
+
+diff --git a/src/conf/domain_conf.c b/src/conf/domain_conf.c
+index e32b16d5..b14fc3f3 100644
+--- a/src/conf/domain_conf.c
++++ b/src/conf/domain_conf.c
+@@ -3859,6 +3859,8 @@ virDomainSecDefFree(virDomainSecDef *def)
+         g_free(def->data.sev.dh_cert);
+         g_free(def->data.sev.session);
+         g_free(def->data.sev.user_id);
++        g_free(def->data.sev.secret_header);
++        g_free(def->data.sev.secret);
+         break;
+     case VIR_DOMAIN_LAUNCH_SECURITY_SEV_SNP:
+         g_free(def->data.sev_snp.guest_visible_workarounds);
+@@ -13747,6 +13749,8 @@ virDomainSEVDefParseXML(virDomainSEVDef *def,
+     def->dh_cert = virXPathString("string(./dhCert)", ctxt);
+     def->session = virXPathString("string(./session)", ctxt);
+     def->user_id = virXPathString("string(./userid)", ctxt);
++    def->secret_header = virXPathString("string(./secretHeader)", ctxt);
++    def->secret = virXPathString("string(./secret)", ctxt);
+ 
+     return 0;
+ }
+@@ -26911,6 +26915,10 @@ virDomainSEVDefFormat(virBuffer *attrBuf,
+ 
+     if (def->user_id)
+         virBufferEscapeString(childBuf, "<userid>%s</userid>\n", def->user_id);
++    if (def->secret_header)
++        virBufferEscapeString(childBuf, "<secretHeader>%s</secretHeader>\n", def->secret_header);
++    if (def->secret)
++        virBufferEscapeString(childBuf, "<secret>%s</secret>\n", def->secret);
+ }
+ 
+ 
+diff --git a/src/conf/domain_conf.h b/src/conf/domain_conf.h
+index 6de7a754..439429db 100644
+--- a/src/conf/domain_conf.h
++++ b/src/conf/domain_conf.h
+@@ -2890,6 +2890,8 @@ struct _virDomainSEVDef {
+     char *session;
+     unsigned int policy;
+     char *user_id;
++    char *secret_header;
++    char *secret;
+ };
+ 
+ 
+diff --git a/src/qemu/qemu_command.c b/src/qemu/qemu_command.c
+index cc550a49..8d4016a5 100644
+--- a/src/qemu/qemu_command.c
++++ b/src/qemu/qemu_command.c
+@@ -9751,6 +9751,8 @@ qemuBuildSEVCommandLine(virDomainObj *vm, virCommand *cmd,
+     qemuDomainObjPrivate *priv = vm->privateData;
+     g_autofree char *dhpath = NULL;
+     g_autofree char *sessionpath = NULL;
++    g_autofree char *secretheaderpath = NULL;
++    g_autofree char *secretpath = NULL;
+ 
+     VIR_DEBUG("policy=0x%x cbitpos=%d reduced_phys_bits=%d",
+               sev->policy, sev->common.cbitpos, sev->common.reduced_phys_bits);
+@@ -9764,6 +9766,12 @@ qemuBuildSEVCommandLine(virDomainObj *vm, virCommand *cmd,
+     if (sev->session)
+         sessionpath = g_strdup_printf("%s/session.base64", priv->libDir);
+ 
++    if (sev->secret_header)
++        secretheaderpath = g_strdup_printf("%s/secret_header.base64", priv->libDir);
++
++    if (sev->secret)
++        secretpath = g_strdup_printf("%s/secret.base64", priv->libDir);
++
+     if (qemuMonitorCreateObjectProps(&props, "sev-guest", "lsec0",
+                                      "u:cbitpos", sev->common.cbitpos,
+                                      "u:reduced-phys-bits", sev->common.reduced_phys_bits,
+@@ -9772,6 +9780,8 @@ qemuBuildSEVCommandLine(virDomainObj *vm, virCommand *cmd,
+                                      "S:session-file", sessionpath,
+                                      "T:kernel-hashes", sev->common.kernel_hashes,
+                                      "S:user-id", sev->user_id,
++                                     "S:secret-header-file", secretheaderpath,
++                                     "S:secret-file", secretpath,
+                                      NULL) < 0)
+         return -1;
+ 
+diff --git a/src/qemu/qemu_process.c b/src/qemu/qemu_process.c
+index 242c9328..d29839c5 100644
+--- a/src/qemu/qemu_process.c
++++ b/src/qemu/qemu_process.c
+@@ -6812,6 +6812,16 @@ qemuProcessPrepareSEVGuestInput(virDomainObj *vm)
+             return -1;
+     }
+ 
++    if (sev->secret_header) {
++        if (qemuProcessSEVCreateFile(vm, "secret_header", sev->secret_header) < 0)
++            return -1;
++    }
++
++    if (sev->secret) {
++        if (qemuProcessSEVCreateFile(vm, "secret", sev->secret) < 0)
++            return -1;
++    }
++
+     return 0;
+ }
+ 
+-- 
+2.25.1
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -3,3 +3,5 @@ forward/Reduce-udevadm-settle-timeout-to-10-seconds.patch
 debian/Debianize-libvirt-guests.patch
 debian/apparmor_profiles_local_include.patch
 debian/Use-sensible-editor-by-default.patch
+deepin/0001-conf-qemu-add-libvirt-support-reuse-id-for-hygon-CSV.patch
+deepin/0002-conf-qemu-support-provide-inject-secret-for-Hygon-CS.patch


### PR DESCRIPTION
1. Support reuse ASID feature in libvirt, the VM's xml should contains userid element.
```
<launchSecurity type='sev'>
  <policy>0x0081</policy>
  <cbitpos>47</cbitpos>
  <reducedPhysBits>5</reducedPhysBits>
  <userid>usertest</userid>
</launchSecurity>
```

2. Support provide secret data for Hygon CSV in libvirt, the VM's XML should contains dhCert, session, secretHeader and secret elements.
```
<launchSecurity type='sev'>
  <policy>0x0001</policy>
  <cbitpos>47</cbitpos>
  <reducePhysBits>5</reducedPhysBits>
  <dhCert>2YjZitCin2LnYqSdiq2YQ=</dhCert>
  <session>aGVsbG8d291b2xk=</session>
  <secretHeader>QmVzdCBdZXZpY2Ugd2l0aCBQ5YWF5L2T5paH5a2XIGFuZCBQSdGVzdGluZw==</secretHeader>
  <secret>5L2g5aW977yM6KGo5qC45LqG77yB</secret>
</launchSecurity>
```