### PR TITLE
Fix libvirtd.policy

### DIFF
--- a/src/remote/libvirtd.policy
+++ b/src/remote/libvirtd.policy
@@ -28,6 +28,12 @@ License along with this library.  If not, see
     <action id="org.libvirt.unix.monitor">
       <description>Monitor local virtualized systems</description>
       <message>System policy prevents monitoring of local virtualized systems</message>
+      <message xml:lang="zh_CN">打开虚拟机需要管理员权限</message>
+      <message xml:lang="zh_TW">啟動虛擬機需要管理員權限</message>
+      <message xml:lang="zh_HK">啟動虛擬機需要管理員權限</message>
+      <message xml:lang="ja_JP">仮想マシンを起動するには管理者権限が必要です</message>
+      <message xml:lang="fr_FR">Lancer une machine virtuelle nécessite des privilèges administrateur</message>
+
       <defaults>
         <!-- Any program can use libvirt in read-only mode for monitoring,
              even if not part of a session -->
@@ -40,6 +46,12 @@ License along with this library.  If not, see
     <action id="org.libvirt.unix.manage">
       <description>Manage local virtualized systems</description>
       <message>System policy prevents management of local virtualized systems</message>
+      <message xml:lang="zh_CN">打开虚拟机需要管理员权限</message>
+      <message xml:lang="zh_TW">啟動虛擬機需要管理員權限</message>
+      <message xml:lang="zh_HK">啟動虛擬機需要管理員權限</message>
+      <message xml:lang="ja_JP">仮想マシンを起動するには管理者権限が必要です</message>
+      <message xml:lang="fr_FR">Lancer une machine virtuelle nécessite des privilèges administrateur</message>
+
       <defaults>
         <!-- Any program can use libvirt in read/write mode if they
              provide the root password -->


### PR DESCRIPTION
On fully localized systems, the Polkit authorization popup for libvirt still shows English text:

> "Authentication is required to manage local virtualized systems"

This is because the message in `org.libvirt.unix.policy` is hardcoded in English and not wrapped with `<_message>` for translation.

I propose:
1. Add `<_message>` support in the policy file (via `.in` template)
2. Allow translations via the existing `po/` infrastructure

This would greatly improve UX for non-English users.

Thanks!