### PR TITLE
feat: Add support for ARM-CCA confidential computing features

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libvirt (10.7.0-3deepin4) unstable; urgency=medium
+
+  * feat: Add support for ARM-CCA confidential computing features
+
+ -- WangYuli <wangyuli@aosc.io>  Fri, 05 Dec 2025 14:15:35 +0800
+
 libvirt (10.7.0-3deepin3) unstable; urgency=medium
 
   * feat: add sw64 support

--- a/debian/patches/backport/0001-src-Add-ARM-CCA-support-in-qemu-driver-to-launch-VM.patch
+++ b/debian/patches/backport/0001-src-Add-ARM-CCA-support-in-qemu-driver-to-launch-VM.patch
@@ -1,0 +1,384 @@
+From 0c394e3cd79402a9a0741b3ca980379f1cc78a5e Mon Sep 17 00:00:00 2001
+From: WangYuli <wangyuli@aosc.io>
+Date: Fri, 5 Dec 2025 12:46:45 +0800
+Subject: [PATCH 1/3] src: Add ARM CCA support in qemu driver to launch VM
+
+bugzilla:https://gitee.com/openeuler/libvirt/issues/ICU4UF?from=project-issue
+reference:https://patchew.org/Libvirt/20250612071418.2926384-1-fj1078ii@aa.jp.fujitsu.com/
+
+--------------------------------
+
+src: Add ARM CCA support in qemu driver to launch VM
+
+- Add ARM CCA support to the qemu driver for aarch64 systems.
+
+[XML example]
+<domain>
+  ...
+  <launchsecurity type='cca'>
+    <measurement-algo>sha256</measurement-algo>
+  </launchsecurity>
+  ...
+</domain>
+
+Signed-off-by: Kazuhiro Abe <fj1078ii@aa.jp.fujitsu.com>
+Signed-off-by: rpm-build <rpm-build>
+Signed-off-by: WangYuli <wangyuli@aosc.io>
+---
+ docs/formatdomain.rst          | 43 ++++++++++++++++++++++++++++++++++
+ src/conf/domain_capabilities.h |  6 +++++
+ src/conf/domain_conf.c         | 25 ++++++++++++++++++++
+ src/conf/domain_conf.h         |  9 +++++++
+ src/conf/virconftypes.h        |  2 ++
+ src/qemu/qemu_capabilities.c   |  6 +++++
+ src/qemu/qemu_capabilities.h   |  3 +++
+ src/qemu/qemu_command.c        | 28 ++++++++++++++++++++++
+ src/qemu/qemu_firmware.c       |  1 +
+ src/qemu/qemu_namespace.c      |  2 ++
+ src/qemu/qemu_process.c        |  4 ++++
+ src/qemu/qemu_validate.c       |  4 ++++
+ 12 files changed, 133 insertions(+)
+
+diff --git a/docs/formatdomain.rst b/docs/formatdomain.rst
+index 47d3e212..3b169a01 100644
+--- a/docs/formatdomain.rst
++++ b/docs/formatdomain.rst
+@@ -9028,6 +9028,49 @@ The ``<launchSecurity/>`` element then accepts the following child elements:
+    blob to provide to the guest, as documented for the 'HOST_DATA' parameter of
+    the SNP_LAUNCH_FINISH command in the SEV-SNP firmware ABI.
+ 
++The contents of the ``<launchSecurity type='cca'>`` element is used to create
++RealmVM using the Arm CCA feature (Confidential Compute Architecture).
++CCA :since:`Since 11.0.0` enhances the virtualization capabilities of the
++platform by separating the management of resources from access to those resources.
++This is achieved by extending the TrustZone of Cortex-A's Normal and Secure
++world concepts and adding the Realm world and the underlying Root world.
++The Secure Monitor runs in the root world and manages the transition between
++these security states. For more information see the Learn the architecture -
++Arm Confidential Compute Architecture software stack:
++`<https://developer.arm.com/documentation/den0127/latest>`__
++
++::
++
++  <domain>
++    ...
++    <launchSecurity type='cca' measurement-log='yes'>
++      <measurement-algo>sha256</measurement-algo>
++      <personalization-value>...</personalization-value>
++    </launchSecurity>
++    ...
++  </domain>
++
++The ``<launchSecurity/>`` element accepts the following attributes:
++
++``measurement-algo``
++   The optional ``measurement-algo`` element determines algorithm used to
++   describe blob hashes.
++
++``personalization-value``
++   The optional ``personalization-value`` element is used to configure
++   the Realm Personalization Value (RPV). The Realm Personalization
++   Value (RPV) is provided by the user to distinguish Realms that have
++   the same initial measurement. The personalization-value for libvirt
++   must be an 88-character string representing the Base64 encoding of
++   the 64-byte hexadecimal value defined in the RMM specification.
++   Ensure that you encode the 64-byte hex value from the RMM specification
++   using Base64 before providing it to libvirt.
++
++``measurement-log``
++   The optional ``measurement-log`` element provides a way to create
++   an event log in the format defined by the Trusted Computing Group
++   for TPM2.
++
+ 
+ Example configs
+ ===============
+diff --git a/src/conf/domain_capabilities.h b/src/conf/domain_capabilities.h
+index 2a4596ac..01076c32 100644
+--- a/src/conf/domain_capabilities.h
++++ b/src/conf/domain_capabilities.h
+@@ -239,6 +239,12 @@ struct _virSGXCapability {
+     virSGXSection *sgxSections;
+ };
+ 
++typedef struct _virCCACapability virCCACapability;
++struct _virCCACapability {
++    size_t nCcaMeasurementAlgo;
++    char **ccaMeasurementAlgo;
++};
++
+ STATIC_ASSERT_ENUM(VIR_DOMAIN_CRYPTO_MODEL_LAST);
+ STATIC_ASSERT_ENUM(VIR_DOMAIN_CRYPTO_TYPE_LAST);
+ STATIC_ASSERT_ENUM(VIR_DOMAIN_CRYPTO_BACKEND_LAST);
+diff --git a/src/conf/domain_conf.c b/src/conf/domain_conf.c
+index cc2c606b..b90b766d 100644
+--- a/src/conf/domain_conf.c
++++ b/src/conf/domain_conf.c
+@@ -1515,6 +1515,7 @@ VIR_ENUM_IMPL(virDomainLaunchSecurity,
+               "sev",
+               "sev-snp",
+               "s390-pv",
++              "cca",
+ );
+ 
+ VIR_ENUM_IMPL(virDomainPstoreBackend,
+@@ -3868,6 +3869,10 @@ virDomainSecDefFree(virDomainSecDef *def)
+         g_free(def->data.sev_snp.id_auth);
+         g_free(def->data.sev_snp.host_data);
+         break;
++    case VIR_DOMAIN_LAUNCH_SECURITY_CCA:
++        g_free(def->data.cca.measurement_algo);
++        g_free(def->data.cca.personalization_value);
++        break;
+     case VIR_DOMAIN_LAUNCH_SECURITY_PV:
+     case VIR_DOMAIN_LAUNCH_SECURITY_NONE:
+     case VIR_DOMAIN_LAUNCH_SECURITY_LAST:
+@@ -13791,6 +13796,21 @@ virDomainSEVSNPDefParseXML(virDomainSEVSNPDef *def,
+ }
+ 
+ 
++static int
++virDomainCCADefParseXML(virDomainCCADef *def,
++                        xmlXPathContextPtr ctxt)
++{
++    def->measurement_algo = virXPathString("string(./measurement-algo)", ctxt);
++    def->personalization_value = virXPathString("string(./personalization-value)", ctxt);
++
++    if (virXMLPropTristateBool(ctxt->node, "measurement-log", VIR_XML_PROP_NONE,
++                               &def->measurement_log) < 0)
++        return -1;
++
++    return 0;
++}
++
++
+ static virDomainSecDef *
+ virDomainSecDefParseXML(xmlNodePtr lsecNode,
+                         xmlXPathContextPtr ctxt)
+@@ -13816,6 +13836,10 @@ virDomainSecDefParseXML(xmlNodePtr lsecNode,
+         break;
+     case VIR_DOMAIN_LAUNCH_SECURITY_PV:
+         break;
++    case VIR_DOMAIN_LAUNCH_SECURITY_CCA:
++        if (virDomainCCADefParseXML(&sec->data.cca, ctxt) < 0)
++            return NULL;
++        break;
+     case VIR_DOMAIN_LAUNCH_SECURITY_NONE:
+     case VIR_DOMAIN_LAUNCH_SECURITY_LAST:
+     default:
+@@ -26977,6 +27001,7 @@ virDomainSecDefFormat(virBuffer *buf, virDomainSecDef *sec)
+         break;
+ 
+     case VIR_DOMAIN_LAUNCH_SECURITY_PV:
++    case VIR_DOMAIN_LAUNCH_SECURITY_CCA:
+         break;
+ 
+     case VIR_DOMAIN_LAUNCH_SECURITY_NONE:
+diff --git a/src/conf/domain_conf.h b/src/conf/domain_conf.h
+index 439429db..f16ffa0c 100644
+--- a/src/conf/domain_conf.h
++++ b/src/conf/domain_conf.h
+@@ -2870,6 +2870,7 @@ typedef enum {
+     VIR_DOMAIN_LAUNCH_SECURITY_SEV,
+     VIR_DOMAIN_LAUNCH_SECURITY_SEV_SNP,
+     VIR_DOMAIN_LAUNCH_SECURITY_PV,
++    VIR_DOMAIN_LAUNCH_SECURITY_CCA,
+ 
+     VIR_DOMAIN_LAUNCH_SECURITY_LAST,
+ } virDomainLaunchSecurity;
+@@ -2907,11 +2908,19 @@ struct _virDomainSEVSNPDef {
+ };
+ 
+ 
++struct _virDomainCCADef {
++    char *measurement_algo;
++    char *personalization_value;
++    virTristateBool measurement_log;
++};
++
++
+ struct _virDomainSecDef {
+     virDomainLaunchSecurity sectype;
+     union {
+         virDomainSEVDef sev;
+         virDomainSEVSNPDef sev_snp;
++        virDomainCCADef cca;
+     } data;
+ };
+ 
+diff --git a/src/conf/virconftypes.h b/src/conf/virconftypes.h
+index f18ebcca..76218f51 100644
+--- a/src/conf/virconftypes.h
++++ b/src/conf/virconftypes.h
+@@ -216,6 +216,8 @@ typedef struct _virDomainSEVDef virDomainSEVDef;
+ 
+ typedef struct _virDomainSEVSNPDef virDomainSEVSNPDef;
+ 
++typedef struct _virDomainCCADef virDomainCCADef;
++
+ typedef struct _virDomainSecDef virDomainSecDef;
+ 
+ typedef struct _virDomainShmemDef virDomainShmemDef;
+diff --git a/src/qemu/qemu_capabilities.c b/src/qemu/qemu_capabilities.c
+index 0da12800..d3bd015e 100644
+--- a/src/qemu/qemu_capabilities.c
++++ b/src/qemu/qemu_capabilities.c
+@@ -715,6 +715,9 @@ VIR_ENUM_IMPL(virQEMUCaps,
+               "acpi-erst", /* QEMU_CAPS_DEVICE_ACPI_ERST */
+               "intel-iommu.dma-translation", /* QEMU_CAPS_INTEL_IOMMU_DMA_TRANSLATION */
+               "machine-i8042-opt", /* QEMU_CAPS_MACHINE_I8042_OPT */
++
++              /* 465 */
++              "rme-guest", /* QEMU_CAPS_CCA_GUEST */
+     );
+ 
+ 
+@@ -800,6 +803,8 @@ struct _virQEMUCaps {
+ 
+     virSGXCapability *sgxCapabilities;
+ 
++    virCCACapability *ccaCapabilities;
++
+     virDomainCapsFeatureHyperv *hypervCapabilities;
+ 
+     /* Capabilities which may differ depending on the accelerator. */
+@@ -1406,6 +1411,7 @@ struct virQEMUCapsStringFlags virQEMUCapsObjectTypes[] = {
+     { "virtio-sound-device", QEMU_CAPS_DEVICE_VIRTIO_SOUND },
+     { "sev-snp-guest", QEMU_CAPS_SEV_SNP_GUEST },
+     { "acpi-erst", QEMU_CAPS_DEVICE_ACPI_ERST },
++    { "rme-guest", QEMU_CAPS_CCA_GUEST },
+ };
+ 
+ 
+diff --git a/src/qemu/qemu_capabilities.h b/src/qemu/qemu_capabilities.h
+index 5036d49a..1eb94f41 100644
+--- a/src/qemu/qemu_capabilities.h
++++ b/src/qemu/qemu_capabilities.h
+@@ -695,6 +695,9 @@ typedef enum { /* virQEMUCapsFlags grouping marker for syntax-check */
+     QEMU_CAPS_INTEL_IOMMU_DMA_TRANSLATION, /* intel-iommu.dma-translation */
+     QEMU_CAPS_MACHINE_I8042_OPT, /* -machine xxx,i8042=on/off; use virQEMUCapsSupportsI8042Toggle() to query this capability */
+ 
++    /* 465 */
++    QEMU_CAPS_CCA_GUEST, /* -object rme-guest */
++
+     QEMU_CAPS_LAST /* this must always be the last item */
+ } virQEMUCapsFlags;
+ 
+diff --git a/src/qemu/qemu_command.c b/src/qemu/qemu_command.c
+index 8d4016a5..dee0b738 100644
+--- a/src/qemu/qemu_command.c
++++ b/src/qemu/qemu_command.c
+@@ -7085,6 +7085,9 @@ qemuBuildMachineCommandLine(virCommand *cmd,
+         case VIR_DOMAIN_LAUNCH_SECURITY_PV:
+             virBufferAddLit(&buf, ",confidential-guest-support=lsec0");
+             break;
++        case VIR_DOMAIN_LAUNCH_SECURITY_CCA:
++            virBufferAddLit(&buf, ",confidential-guest-support=rme0");
++            break;
+         case VIR_DOMAIN_LAUNCH_SECURITY_NONE:
+         case VIR_DOMAIN_LAUNCH_SECURITY_LAST:
+             virReportEnumRangeError(virDomainLaunchSecurity, def->sec->sectype);
+@@ -9849,6 +9852,29 @@ qemuBuildPVCommandLine(virDomainObj *vm, virCommand *cmd)
+ }
+ 
+ 
++static int
++qemuBuildCCACommandLine(virCommand *cmd, virDomainCCADef *cca, qemuDomainObjPrivate *priv)
++{
++    g_autoptr(virJSONValue) props = NULL;
++
++    VIR_DEBUG("measurement_algorithm=%s personalization_value=%s measurement_log=%d",
++              cca->measurement_algo, cca->personalization_value,
++              cca->measurement_log);
++
++    if (qemuMonitorCreateObjectProps(&props, "rme-guest", "rme0",
++                                     "S:measurement-algorithm", cca->measurement_algo,
++                                     "S:personalization-value", cca->personalization_value,
++                                     "T:measurement-log", cca->measurement_log,
++                                     NULL) < 0)
++        return -1;
++
++    if (qemuBuildObjectCommandlineFromJSON(cmd, props, priv->qemuCaps) < 0)
++        return -1;
++
++    return 0;
++}
++
++
+ static int
+ qemuBuildSecCommandLine(virDomainObj *vm, virCommand *cmd,
+                         virDomainSecDef *sec)
+@@ -9866,6 +9892,8 @@ qemuBuildSecCommandLine(virDomainObj *vm, virCommand *cmd,
+     case VIR_DOMAIN_LAUNCH_SECURITY_PV:
+         return qemuBuildPVCommandLine(vm, cmd);
+         break;
++    case VIR_DOMAIN_LAUNCH_SECURITY_CCA:
++        return qemuBuildCCACommandLine(cmd, &sec->data.cca, vm->privateData);
+     case VIR_DOMAIN_LAUNCH_SECURITY_NONE:
+     case VIR_DOMAIN_LAUNCH_SECURITY_LAST:
+         virReportEnumRangeError(virDomainLaunchSecurity, sec->sectype);
+diff --git a/src/qemu/qemu_firmware.c b/src/qemu/qemu_firmware.c
+index 914f8596..9bf57164 100644
+--- a/src/qemu/qemu_firmware.c
++++ b/src/qemu/qemu_firmware.c
+@@ -1371,6 +1371,7 @@ qemuFirmwareMatchDomain(const virDomainDef *def,
+             }
+             break;
+         case VIR_DOMAIN_LAUNCH_SECURITY_PV:
++        case VIR_DOMAIN_LAUNCH_SECURITY_CCA:
+             break;
+         case VIR_DOMAIN_LAUNCH_SECURITY_NONE:
+         case VIR_DOMAIN_LAUNCH_SECURITY_LAST:
+diff --git a/src/qemu/qemu_namespace.c b/src/qemu/qemu_namespace.c
+index bbe3d5a1..69295306 100644
+--- a/src/qemu/qemu_namespace.c
++++ b/src/qemu/qemu_namespace.c
+@@ -660,6 +660,8 @@ qemuDomainSetupLaunchSecurity(virDomainObj *vm,
+ 
+         VIR_DEBUG("Set up launch security for SEV");
+         break;
++    case VIR_DOMAIN_LAUNCH_SECURITY_CCA:
++        break;
+     case VIR_DOMAIN_LAUNCH_SECURITY_PV:
+         break;
+     case VIR_DOMAIN_LAUNCH_SECURITY_NONE:
+diff --git a/src/qemu/qemu_process.c b/src/qemu/qemu_process.c
+index d29839c5..0f264f53 100644
+--- a/src/qemu/qemu_process.c
++++ b/src/qemu/qemu_process.c
+@@ -6757,6 +6757,8 @@ qemuProcessPrepareDomain(virQEMUDriver *driver,
+             if (qemuProcessUpdateSEVInfo(vm) < 0)
+                 return -1;
+             break;
++        case VIR_DOMAIN_LAUNCH_SECURITY_CCA:
++            break;
+         case VIR_DOMAIN_LAUNCH_SECURITY_PV:
+             break;
+         case VIR_DOMAIN_LAUNCH_SECURITY_NONE:
+@@ -6839,6 +6841,8 @@ qemuProcessPrepareLaunchSecurityGuestInput(virDomainObj *vm)
+         return qemuProcessPrepareSEVGuestInput(vm);
+     case VIR_DOMAIN_LAUNCH_SECURITY_SEV_SNP:
+         break;
++    case VIR_DOMAIN_LAUNCH_SECURITY_CCA:
++        return 0;
+     case VIR_DOMAIN_LAUNCH_SECURITY_PV:
+         return 0;
+     case VIR_DOMAIN_LAUNCH_SECURITY_NONE:
+diff --git a/src/qemu/qemu_validate.c b/src/qemu/qemu_validate.c
+index 3c40f76c..b18573d5 100644
+--- a/src/qemu/qemu_validate.c
++++ b/src/qemu/qemu_validate.c
+@@ -1365,6 +1365,10 @@ qemuValidateDomainDef(const virDomainDef *def,
+                 return -1;
+             }
+             break;
++
++        case VIR_DOMAIN_LAUNCH_SECURITY_CCA:
++            break;
++
+         case VIR_DOMAIN_LAUNCH_SECURITY_NONE:
+         case VIR_DOMAIN_LAUNCH_SECURITY_LAST:
+             virReportEnumRangeError(virDomainLaunchSecurity, def->sec->sectype);
+-- 
+2.51.0
+

--- a/debian/patches/backport/0002-src-Add-ARM-CCA-support-in-domain-capabilities-comma.patch
+++ b/debian/patches/backport/0002-src-Add-ARM-CCA-support-in-domain-capabilities-comma.patch
@@ -1,0 +1,1579 @@
+From 123b913175cd83b2acbd37d9f8d4b9fc3dff466b Mon Sep 17 00:00:00 2001
+From: WangYuli <wangyuli@aosc.io>
+Date: Fri, 5 Dec 2025 12:59:39 +0800
+Subject: [PATCH 2/3] src: Add ARM CCA support in domain capabilities command
+
+bugzilla:https://gitee.com/openeuler/libvirt/issues/ICU4UF?from=project-issue
+reference:https://patchew.org/Libvirt/20250612071418.2926384-1-fj1078ii@aa.jp.fujitsu.com/
+
+----------------------------------------
+
+- Add ARM CCA support in domain capabilies XML schema.
+
+[Capability example]
+- Execution results of 'virsh domcapability" on qemu
+<domaincapabilities>
+...
+  <features>
+    ...
+    </sgx>
+    <cca supported='yes'>
+    <enum name='measurement-algo'>
+      <value>sha256</value>
+      <value>sha512</value>
+    </enum>
+    </cca>
+    <hyperv supported='yes'>
+    ...
+  </features>
+</domaincapabilities>
+
+Signed-off-by: Kazuhiro Abe <fj1078ii@aa.jp.fujitsu.com>
+Signed-off-by: rpm-build <rpm-build>
+Signed-off-by: WangYuli <wangyuli@aosc.io>
+---
+ docs/formatdomaincaps.rst                     | 21 +++-
+ src/conf/domain_capabilities.c                | 48 +++++++++
+ src/conf/domain_capabilities.h                |  6 ++
+ src/libvirt_private.syms                      |  1 +
+ src/qemu/qemu_capabilities.c                  | 28 ++++++
+ src/qemu/qemu_monitor.c                       | 10 ++
+ src/qemu/qemu_monitor.h                       |  3 +
+ src/qemu/qemu_monitor_json.c                  | 98 +++++++++++++++++++
+ src/qemu/qemu_monitor_json.h                  |  4 +
+ tests/domaincapsdata/bhyve_basic.x86_64.xml   |  1 +
+ tests/domaincapsdata/bhyve_fbuf.x86_64.xml    |  1 +
+ tests/domaincapsdata/bhyve_uefi.x86_64.xml    |  1 +
+ tests/domaincapsdata/empty.xml                |  1 +
+ tests/domaincapsdata/libxl-xenfv.xml          |  1 +
+ tests/domaincapsdata/libxl-xenpv.xml          |  1 +
+ .../domaincapsdata/qemu_4.2.0-q35.x86_64.xml  |  1 +
+ .../domaincapsdata/qemu_4.2.0-tcg.x86_64.xml  |  1 +
+ .../qemu_4.2.0-virt.aarch64.xml               |  1 +
+ tests/domaincapsdata/qemu_4.2.0.aarch64.xml   |  1 +
+ tests/domaincapsdata/qemu_4.2.0.ppc64.xml     |  1 +
+ tests/domaincapsdata/qemu_4.2.0.s390x.xml     |  1 +
+ tests/domaincapsdata/qemu_4.2.0.x86_64.xml    |  1 +
+ .../domaincapsdata/qemu_5.0.0-q35.x86_64.xml  |  1 +
+ .../qemu_5.0.0-tcg-virt.riscv64.xml           |  1 +
+ .../domaincapsdata/qemu_5.0.0-tcg.x86_64.xml  |  1 +
+ .../qemu_5.0.0-virt.aarch64.xml               |  1 +
+ .../qemu_5.0.0-virt.riscv64.xml               |  1 +
+ tests/domaincapsdata/qemu_5.0.0.aarch64.xml   |  1 +
+ tests/domaincapsdata/qemu_5.0.0.ppc64.xml     |  1 +
+ tests/domaincapsdata/qemu_5.0.0.x86_64.xml    |  1 +
+ .../domaincapsdata/qemu_5.1.0-q35.x86_64.xml  |  1 +
+ .../domaincapsdata/qemu_5.1.0-tcg.x86_64.xml  |  1 +
+ tests/domaincapsdata/qemu_5.1.0.sparc.xml     |  1 +
+ tests/domaincapsdata/qemu_5.1.0.x86_64.xml    |  1 +
+ .../domaincapsdata/qemu_5.2.0-q35.x86_64.xml  |  1 +
+ .../qemu_5.2.0-tcg-virt.riscv64.xml           |  1 +
+ .../domaincapsdata/qemu_5.2.0-tcg.x86_64.xml  |  1 +
+ .../qemu_5.2.0-virt.aarch64.xml               |  1 +
+ .../qemu_5.2.0-virt.riscv64.xml               |  1 +
+ tests/domaincapsdata/qemu_5.2.0.aarch64.xml   |  1 +
+ tests/domaincapsdata/qemu_5.2.0.ppc64.xml     |  1 +
+ tests/domaincapsdata/qemu_5.2.0.s390x.xml     |  1 +
+ tests/domaincapsdata/qemu_5.2.0.x86_64.xml    |  1 +
+ .../domaincapsdata/qemu_6.0.0-q35.x86_64.xml  |  1 +
+ .../domaincapsdata/qemu_6.0.0-tcg.x86_64.xml  |  1 +
+ .../qemu_6.0.0-virt.aarch64.xml               |  1 +
+ tests/domaincapsdata/qemu_6.0.0.aarch64.xml   |  1 +
+ tests/domaincapsdata/qemu_6.0.0.s390x.xml     |  1 +
+ tests/domaincapsdata/qemu_6.0.0.x86_64.xml    |  1 +
+ .../domaincapsdata/qemu_6.1.0-q35.x86_64.xml  |  1 +
+ .../domaincapsdata/qemu_6.1.0-tcg.x86_64.xml  |  1 +
+ tests/domaincapsdata/qemu_6.1.0.x86_64.xml    |  1 +
+ .../domaincapsdata/qemu_6.2.0-q35.x86_64.xml  |  1 +
+ .../domaincapsdata/qemu_6.2.0-tcg.x86_64.xml  |  1 +
+ .../qemu_6.2.0-virt.aarch64.xml               |  1 +
+ tests/domaincapsdata/qemu_6.2.0.aarch64.xml   |  1 +
+ tests/domaincapsdata/qemu_6.2.0.ppc64.xml     |  1 +
+ tests/domaincapsdata/qemu_6.2.0.x86_64.xml    |  1 +
+ .../qemu_7.0.0-hvf.aarch64+hvf.xml            |  1 +
+ .../domaincapsdata/qemu_7.0.0-q35.x86_64.xml  |  1 +
+ .../domaincapsdata/qemu_7.0.0-tcg.x86_64.xml  |  1 +
+ .../qemu_7.0.0-virt.aarch64.xml               |  1 +
+ tests/domaincapsdata/qemu_7.0.0.aarch64.xml   |  1 +
+ tests/domaincapsdata/qemu_7.0.0.ppc64.xml     |  1 +
+ tests/domaincapsdata/qemu_7.0.0.x86_64.xml    |  1 +
+ .../domaincapsdata/qemu_7.1.0-q35.x86_64.xml  |  1 +
+ .../domaincapsdata/qemu_7.1.0-tcg.x86_64.xml  |  1 +
+ tests/domaincapsdata/qemu_7.1.0.ppc64.xml     |  1 +
+ tests/domaincapsdata/qemu_7.1.0.x86_64.xml    |  1 +
+ .../qemu_7.2.0-hvf.x86_64+hvf.xml             |  1 +
+ .../domaincapsdata/qemu_7.2.0-q35.x86_64.xml  |  1 +
+ .../qemu_7.2.0-tcg.x86_64+hvf.xml             |  1 +
+ .../domaincapsdata/qemu_7.2.0-tcg.x86_64.xml  |  1 +
+ tests/domaincapsdata/qemu_7.2.0.ppc.xml       |  1 +
+ tests/domaincapsdata/qemu_7.2.0.x86_64.xml    |  1 +
+ .../domaincapsdata/qemu_8.0.0-q35.x86_64.xml  |  1 +
+ .../qemu_8.0.0-tcg-virt.riscv64.xml           |  1 +
+ .../domaincapsdata/qemu_8.0.0-tcg.x86_64.xml  |  1 +
+ .../qemu_8.0.0-virt.riscv64.xml               |  1 +
+ tests/domaincapsdata/qemu_8.0.0.x86_64.xml    |  1 +
+ .../domaincapsdata/qemu_8.1.0-q35.x86_64.xml  |  1 +
+ .../domaincapsdata/qemu_8.1.0-tcg.x86_64.xml  |  1 +
+ tests/domaincapsdata/qemu_8.1.0.s390x.xml     |  1 +
+ tests/domaincapsdata/qemu_8.1.0.x86_64.xml    |  1 +
+ .../domaincapsdata/qemu_8.2.0-q35.x86_64.xml  |  1 +
+ .../qemu_8.2.0-tcg-virt.loongarch64.xml       |  1 +
+ .../domaincapsdata/qemu_8.2.0-tcg.x86_64.xml  |  1 +
+ .../qemu_8.2.0-virt.aarch64.xml               |  1 +
+ .../qemu_8.2.0-virt.loongarch64.xml           |  1 +
+ tests/domaincapsdata/qemu_8.2.0.aarch64.xml   |  1 +
+ tests/domaincapsdata/qemu_8.2.0.armv7l.xml    |  1 +
+ tests/domaincapsdata/qemu_8.2.0.s390x.xml     |  1 +
+ tests/domaincapsdata/qemu_8.2.0.x86_64.xml    |  1 +
+ .../domaincapsdata/qemu_9.0.0-q35.x86_64.xml  |  1 +
+ .../domaincapsdata/qemu_9.0.0-tcg.x86_64.xml  |  1 +
+ tests/domaincapsdata/qemu_9.0.0.sparc.xml     |  1 +
+ tests/domaincapsdata/qemu_9.0.0.x86_64.xml    |  1 +
+ .../domaincapsdata/qemu_9.1.0-q35.x86_64.xml  |  1 +
+ .../domaincapsdata/qemu_9.1.0-tcg.x86_64.xml  |  1 +
+ tests/domaincapsdata/qemu_9.1.0.x86_64.xml    |  1 +
+ 100 files changed, 309 insertions(+), 1 deletion(-)
+
+diff --git a/docs/formatdomaincaps.rst b/docs/formatdomaincaps.rst
+index 712d8b44..935a81a3 100644
+--- a/docs/formatdomaincaps.rst
++++ b/docs/formatdomaincaps.rst
+@@ -817,6 +817,24 @@ document store. In order to use SGX with libvirt have a look at `SGX in domain X
+ ``sections``
+    The sections of the SGX enclave page cache (called EPC).
+ 
++CCA capabilities
++^^^^^^^^^^^^^^^^
++
++Arm Confidential Compute Architecture (CCA) capabilities are exposed under the
++``cca`` element.
++
++Arm CCA is a system solution comprised of hardware and software components that
++maximizes the security of data on devices and in the cloud.
++CCA enhances the virtualization capabilities of the platform by separating the
++management of resources from access to those resources.
++
++For more details on the CCA feature, please follow resources in the CCA developer's
++document store. In order to use CCA with libvirt have a look at `CCA in domain
++XML <formatdomain.html#launch-security>`__
++
++``measurement-algo``
++   Options for the ``measurement-algo`` used to describe blob hashes.
++
+ 
+ Hyper-V Enlightenments
+ ^^^^^^^^^^^^^^^^^^^^^^
+@@ -838,4 +856,5 @@ The ``sectype`` enum corresponds to ``type`` attribute of ``<launchSecurity/>``
+ element as documented in `Launch Security
+ <formatdomain.html#launch-security>`__.  :since:`(Since 10.5.0)` For additional
+ information on individual types, see sections above: `s390-pv capability`_ for
+-S390 PV, `SEV capabilities`_ for AMD SEV and/or AMD SEV-SNP.
++S390 PV, `SEV capabilities`_ for AMD SEV and/or AMD SEV-SNP, `CCA capabilities`_
++for Arm CCA.
+diff --git a/src/conf/domain_capabilities.c b/src/conf/domain_capabilities.c
+index 30540de3..d104d6e8 100644
+--- a/src/conf/domain_capabilities.c
++++ b/src/conf/domain_capabilities.c
+@@ -89,6 +89,25 @@ virSGXCapabilitiesFree(virSGXCapability *cap)
+ }
+ 
+ 
++void
++virCCACapabilitiesFree(virCCACapability *cap)
++{
++    size_t i;
++
++    if (!cap)
++        return;
++
++    if (cap->nCcaMeasurementAlgo)
++        for (i = 0; i < cap->nCcaMeasurementAlgo; i++)
++            g_free(cap->ccaMeasurementAlgo[i]);
++
++    if (cap->ccaMeasurementAlgo)
++        g_free(cap->ccaMeasurementAlgo);
++
++    g_free(cap);
++}
++
++
+ static void
+ virDomainCapsDispose(void *obj)
+ {
+@@ -102,6 +121,7 @@ virDomainCapsDispose(void *obj)
+     virCPUDefFree(caps->cpu.hostModel);
+     virSEVCapabilitiesFree(caps->sev);
+     virSGXCapabilitiesFree(caps->sgx);
++    virCCACapabilitiesFree(caps->cca);
+     g_free(caps->hyperv);
+ 
+     values = &caps->os.loader.values;
+@@ -706,6 +726,33 @@ virDomainCapsFeatureSGXFormat(virBuffer *buf,
+     virBufferAddLit(buf, "</sgx>\n");
+ }
+ 
++static void
++virDomainCapsFeatureCCAFormat(virBuffer *buf,
++                              const virCCACapability *cca)
++{
++    size_t i;
++
++    if (!cca) {
++        virBufferAddLit(buf, "<cca supported='no'/>\n");
++        return;
++    }
++
++    virBufferAddLit(buf, "<cca supported='yes'>\n");
++    virBufferAdjustIndent(buf, 2);
++
++    virBufferAddLit(buf, "<enum name='measurement-algo'>\n");
++    virBufferAdjustIndent(buf, 2);
++    for (i = 0; i < cca->nCcaMeasurementAlgo; i++) {
++        virBufferAsprintf(buf, "<value>%s</value>\n",
++                          cca->ccaMeasurementAlgo[i]);
++    }
++    virBufferAdjustIndent(buf, -2);
++    virBufferAddLit(buf, "</enum>\n");
++
++    virBufferAdjustIndent(buf, -2);
++    virBufferAddLit(buf, "</cca>\n");
++}
++
+ static void
+ virDomainCapsFeatureHypervFormat(virBuffer *buf,
+                                  const virDomainCapsFeatureHyperv *hyperv)
+@@ -753,6 +800,7 @@ virDomainCapsFormatFeatures(const virDomainCaps *caps,
+ 
+     virDomainCapsFeatureSEVFormat(&childBuf, caps->sev);
+     virDomainCapsFeatureSGXFormat(&childBuf, caps->sgx);
++    virDomainCapsFeatureCCAFormat(&childBuf, caps->cca);
+     virDomainCapsFeatureHypervFormat(&childBuf, caps->hyperv);
+     virDomainCapsLaunchSecurityFormat(&childBuf, &caps->launchSecurity);
+ 
+diff --git a/src/conf/domain_capabilities.h b/src/conf/domain_capabilities.h
+index 01076c32..d880d367 100644
+--- a/src/conf/domain_capabilities.h
++++ b/src/conf/domain_capabilities.h
+@@ -306,6 +306,7 @@ struct _virDomainCaps {
+     virDomainCapsFeatureGIC gic;
+     virSEVCapability *sev;
+     virSGXCapability *sgx;
++    virCCACapability *cca;
+     virDomainCapsFeatureHyperv *hyperv;
+     virDomainCapsLaunchSecurity launchSecurity;
+     /* add new domain features here */
+@@ -363,3 +364,8 @@ void
+ virSGXCapabilitiesFree(virSGXCapability *capabilities);
+ 
+ G_DEFINE_AUTOPTR_CLEANUP_FUNC(virSGXCapability, virSGXCapabilitiesFree);
++
++void
++virCCACapabilitiesFree(virCCACapability *capabilities);
++
++G_DEFINE_AUTOPTR_CLEANUP_FUNC(virCCACapability, virCCACapabilitiesFree);
+diff --git a/src/libvirt_private.syms b/src/libvirt_private.syms
+index af40e5dc..07b75ca4 100644
+--- a/src/libvirt_private.syms
++++ b/src/libvirt_private.syms
+@@ -208,6 +208,7 @@ virDomainAuditVcpu;
+ 
+ 
+ # conf/domain_capabilities.h
++virCCACapabilitiesFree;
+ virDomainCapsCPUModelsAdd;
+ virDomainCapsCPUModelsCopy;
+ virDomainCapsCPUModelsGet;
+diff --git a/src/qemu/qemu_capabilities.c b/src/qemu/qemu_capabilities.c
+index d3bd015e..16adfa55 100644
+--- a/src/qemu/qemu_capabilities.c
++++ b/src/qemu/qemu_capabilities.c
+@@ -3539,6 +3539,32 @@ virQEMUCapsProbeQMPSGXCapabilities(virQEMUCaps *qemuCaps,
+ }
+ 
+ 
++static int
++virQEMUCapsProbeQMPCCACapabilities(virQEMUCaps *qemuCaps,
++                                   qemuMonitor *mon)
++{
++    int rc = -1;
++    virCCACapability *caps = NULL;
++
++    if (!virQEMUCapsGet(qemuCaps, QEMU_CAPS_CCA_GUEST))
++        return 0;
++
++    if ((rc = qemuMonitorGetCCACapabilities(mon, &caps)) < 0)
++        return -1;
++
++    /* CCA isn't actually supported */
++    if (rc == 0) {
++        virQEMUCapsClear(qemuCaps, QEMU_CAPS_CCA_GUEST);
++        return 0;
++    }
++
++    virCCACapabilitiesFree(qemuCaps->ccaCapabilities);
++    qemuCaps->ccaCapabilities = caps;
++    return 0;
++}
++
++
++
+ /*
+  * Filter for features which should never be passed to QEMU. Either because
+  * QEMU never supported them or they were dropped as they never did anything
+@@ -5604,6 +5630,8 @@ virQEMUCapsInitQMPMonitor(virQEMUCaps *qemuCaps,
+         return -1;
+     if (virQEMUCapsProbeQMPSGXCapabilities(qemuCaps, mon) < 0)
+         return -1;
++    if (virQEMUCapsProbeQMPCCACapabilities(qemuCaps, mon) < 0)
++        return -1;
+ 
+     virQEMUCapsInitProcessCaps(qemuCaps);
+ 
+diff --git a/src/qemu/qemu_monitor.c b/src/qemu/qemu_monitor.c
+index 7f65c237..ed26846f 100644
+--- a/src/qemu/qemu_monitor.c
++++ b/src/qemu/qemu_monitor.c
+@@ -3442,6 +3442,16 @@ qemuMonitorGetSGXCapabilities(qemuMonitor *mon,
+ }
+ 
+ 
++int
++qemuMonitorGetCCACapabilities(qemuMonitor *mon,
++                              virCCACapability **capabilities)
++{
++    QEMU_CHECK_MONITOR(mon);
++
++    return qemuMonitorJSONGetCCACapabilities(mon, capabilities);
++}
++
++
+ int
+ qemuMonitorNBDServerStart(qemuMonitor *mon,
+                           const virStorageNetHostDef *server,
+diff --git a/src/qemu/qemu_monitor.h b/src/qemu/qemu_monitor.h
+index 57d1b45b..86b6e516 100644
+--- a/src/qemu/qemu_monitor.h
++++ b/src/qemu/qemu_monitor.h
+@@ -836,6 +836,9 @@ int qemuMonitorGetSEVCapabilities(qemuMonitor *mon,
+ int qemuMonitorGetSGXCapabilities(qemuMonitor *mon,
+                                   virSGXCapability **capabilities);
+ 
++int qemuMonitorGetCCACapabilities(qemuMonitor *mon,
++                                  virCCACapability **capabilities);
++
+ typedef enum {
+   QEMU_MONITOR_MIGRATE_RESUME           = 1 << 0, /* resume failed post-copy migration */
+   QEMU_MONITOR_MIGRATION_FLAGS_LAST
+diff --git a/src/qemu/qemu_monitor_json.c b/src/qemu/qemu_monitor_json.c
+index 2db38c10..cb385298 100644
+--- a/src/qemu/qemu_monitor_json.c
++++ b/src/qemu/qemu_monitor_json.c
+@@ -6133,6 +6133,104 @@ qemuMonitorJSONGetSGXCapabilities(qemuMonitor *mon,
+ }
+ 
+ 
++static int
++qemuMonitorJSONGetCCAMeasurementAlgo(qemuMonitor *mon,
++                                     size_t *numalgo,
++                                     char ***malgo)
++{
++    g_autoptr(virJSONValue) cmd = NULL;
++    g_autoptr(virJSONValue) reply = NULL;
++    virJSONValue *caps;
++    virJSONValue *malgolist = NULL;
++    g_auto(GStrv) list = NULL;
++    size_t i;
++    size_t n = 0;
++
++    if (!(cmd = qemuMonitorJSONMakeCommand("query-cca-capabilities",
++                                           NULL)))
++        return -1;
++
++    if (qemuMonitorJSONCommand(mon, cmd, &reply) < 0)
++        return -1;
++
++    /* If the 'query-cca-capabilities' QMP command was not available
++     * we simply successfully return zero capabilities.
++     * This is the current QEMU (=9.1.91) and all non-ARM architectures */
++    if (qemuMonitorJSONHasError(reply, "CommandNotFound"))
++        return 0;
++
++    if (qemuMonitorJSONCheckError(cmd, reply) < 0)
++        return -1;
++
++    caps = virJSONValueObjectGetObject(reply, "return");
++
++    if (!(caps = qemuMonitorJSONGetReply(cmd, reply, VIR_JSON_TYPE_OBJECT)))
++        return -1;
++
++    if ((malgolist = virJSONValueObjectGetArray(caps, "sections"))) {
++        n = virJSONValueArraySize(malgolist);
++
++        /* If the received array is empty, an error is returned. */
++        if (n == 0)
++            return -1;
++
++        list = g_new0(char *, n + 1);
++
++        for (i = 0; i < n; i++) {
++            virJSONValue *cap = virJSONValueArrayGet(malgolist, i);
++            const char *measurement_algo = NULL;
++
++            if (!cap || virJSONValueGetType(cap) != VIR_JSON_TYPE_OBJECT) {
++                virReportError(VIR_ERR_INTERNAL_ERROR, "%s",
++                               _("missing entry in CCA capabilities list"));
++                return -1;
++            }
++
++            if (!(measurement_algo = virJSONValueObjectGetString(cap, "measurement-algo"))) {
++                virReportError(VIR_ERR_INTERNAL_ERROR, "%s",
++                           _("query-cca-capabilities reply was missing 'measurement-algo' field"));
++                return -1;
++            }
++
++            list[i] = g_strdup(measurement_algo);
++        }
++    }
++
++    *numalgo = n;
++    *malgo = g_steal_pointer(&list);
++    return 1;
++}
++
++
++/**
++ * qemuMonitorJSONGetCCACapabilities:
++ * @mon: qemu monitor object
++ * @capabilities: pointer to pointer to a CCA capability structure to be filled
++ *
++ * Returns -1 on error, 0 if CCA is not supported, and 1 if CCA is supported on
++ * the platform.
++ */
++int
++qemuMonitorJSONGetCCACapabilities(qemuMonitor *mon,
++                                  virCCACapability **capabilities)
++{
++    g_autoptr(virCCACapability) capability = NULL;
++    int ret = 0;
++
++    *capabilities = NULL;
++    capability = g_new0(virCCACapability, 1);
++
++    ret = qemuMonitorJSONGetCCAMeasurementAlgo(mon,
++                                               &capability->nCcaMeasurementAlgo,
++                                               &capability->ccaMeasurementAlgo);
++
++    if (ret > 0)
++        *capabilities = g_steal_pointer(&capability);
++
++    return ret;
++}
++
++
+ static virJSONValue *
+ qemuMonitorJSONBuildInetSocketAddress(const char *host,
+                                       const char *port)
+diff --git a/src/qemu/qemu_monitor_json.h b/src/qemu/qemu_monitor_json.h
+index 921dd34e..a522beb2 100644
+--- a/src/qemu/qemu_monitor_json.h
++++ b/src/qemu/qemu_monitor_json.h
+@@ -168,6 +168,10 @@ int
+ qemuMonitorJSONGetSEVCapabilities(qemuMonitor *mon,
+                                   virSEVCapability **capabilities);
+ 
++int
++qemuMonitorJSONGetCCACapabilities(qemuMonitor *mon,
++                                  virCCACapability **capabilities);
++
+ int
+ qemuMonitorJSONMigrate(qemuMonitor *mon,
+                        unsigned int flags,
+diff --git a/tests/domaincapsdata/bhyve_basic.x86_64.xml b/tests/domaincapsdata/bhyve_basic.x86_64.xml
+index dd054577..415c10ea 100644
+--- a/tests/domaincapsdata/bhyve_basic.x86_64.xml
++++ b/tests/domaincapsdata/bhyve_basic.x86_64.xml
+@@ -34,5 +34,6 @@
+     <genid supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/bhyve_fbuf.x86_64.xml b/tests/domaincapsdata/bhyve_fbuf.x86_64.xml
+index 0b1d9c17..68bfd71f 100644
+--- a/tests/domaincapsdata/bhyve_fbuf.x86_64.xml
++++ b/tests/domaincapsdata/bhyve_fbuf.x86_64.xml
+@@ -51,5 +51,6 @@
+     <genid supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/bhyve_uefi.x86_64.xml b/tests/domaincapsdata/bhyve_uefi.x86_64.xml
+index 69fff197..42be6674 100644
+--- a/tests/domaincapsdata/bhyve_uefi.x86_64.xml
++++ b/tests/domaincapsdata/bhyve_uefi.x86_64.xml
+@@ -43,5 +43,6 @@
+     <genid supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/empty.xml b/tests/domaincapsdata/empty.xml
+index 97752ca0..5157d684 100644
+--- a/tests/domaincapsdata/empty.xml
++++ b/tests/domaincapsdata/empty.xml
+@@ -14,5 +14,6 @@
+   <features>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/libxl-xenfv.xml b/tests/domaincapsdata/libxl-xenfv.xml
+index c71d7595..e27f2372 100644
+--- a/tests/domaincapsdata/libxl-xenfv.xml
++++ b/tests/domaincapsdata/libxl-xenfv.xml
+@@ -77,5 +77,6 @@
+     <genid supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/libxl-xenpv.xml b/tests/domaincapsdata/libxl-xenpv.xml
+index 8ae2370b..8b138c16 100644
+--- a/tests/domaincapsdata/libxl-xenpv.xml
++++ b/tests/domaincapsdata/libxl-xenpv.xml
+@@ -67,5 +67,6 @@
+     <genid supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_4.2.0-q35.x86_64.xml b/tests/domaincapsdata/qemu_4.2.0-q35.x86_64.xml
+index e5ffe393..912897ec 100644
+--- a/tests/domaincapsdata/qemu_4.2.0-q35.x86_64.xml
++++ b/tests/domaincapsdata/qemu_4.2.0-q35.x86_64.xml
+@@ -324,6 +324,7 @@
+     <async-teardown supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_4.2.0-tcg.x86_64.xml b/tests/domaincapsdata/qemu_4.2.0-tcg.x86_64.xml
+index a849e8f1..63996a5a 100644
+--- a/tests/domaincapsdata/qemu_4.2.0-tcg.x86_64.xml
++++ b/tests/domaincapsdata/qemu_4.2.0-tcg.x86_64.xml
+@@ -269,6 +269,7 @@
+     <async-teardown supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_4.2.0-virt.aarch64.xml b/tests/domaincapsdata/qemu_4.2.0-virt.aarch64.xml
+index a7c2e0ba..727294ce 100644
+--- a/tests/domaincapsdata/qemu_4.2.0-virt.aarch64.xml
++++ b/tests/domaincapsdata/qemu_4.2.0-virt.aarch64.xml
+@@ -201,6 +201,7 @@
+     <async-teardown supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_4.2.0.aarch64.xml b/tests/domaincapsdata/qemu_4.2.0.aarch64.xml
+index a7c2e0ba..727294ce 100644
+--- a/tests/domaincapsdata/qemu_4.2.0.aarch64.xml
++++ b/tests/domaincapsdata/qemu_4.2.0.aarch64.xml
+@@ -201,6 +201,7 @@
+     <async-teardown supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_4.2.0.ppc64.xml b/tests/domaincapsdata/qemu_4.2.0.ppc64.xml
+index 2c41777e..b42fd490 100644
+--- a/tests/domaincapsdata/qemu_4.2.0.ppc64.xml
++++ b/tests/domaincapsdata/qemu_4.2.0.ppc64.xml
+@@ -169,6 +169,7 @@
+     <async-teardown supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_4.2.0.s390x.xml b/tests/domaincapsdata/qemu_4.2.0.s390x.xml
+index 809ce9c9..51f47657 100644
+--- a/tests/domaincapsdata/qemu_4.2.0.s390x.xml
++++ b/tests/domaincapsdata/qemu_4.2.0.s390x.xml
+@@ -275,6 +275,7 @@
+     <s390-pv supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_4.2.0.x86_64.xml b/tests/domaincapsdata/qemu_4.2.0.x86_64.xml
+index 32ba46eb..2c78cb81 100644
+--- a/tests/domaincapsdata/qemu_4.2.0.x86_64.xml
++++ b/tests/domaincapsdata/qemu_4.2.0.x86_64.xml
+@@ -324,6 +324,7 @@
+     <async-teardown supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_5.0.0-q35.x86_64.xml b/tests/domaincapsdata/qemu_5.0.0-q35.x86_64.xml
+index 70bd7bc4..7cc17456 100644
+--- a/tests/domaincapsdata/qemu_5.0.0-q35.x86_64.xml
++++ b/tests/domaincapsdata/qemu_5.0.0-q35.x86_64.xml
+@@ -326,6 +326,7 @@
+     <async-teardown supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_5.0.0-tcg-virt.riscv64.xml b/tests/domaincapsdata/qemu_5.0.0-tcg-virt.riscv64.xml
+index c487d467..ce4f0f9f 100644
+--- a/tests/domaincapsdata/qemu_5.0.0-tcg-virt.riscv64.xml
++++ b/tests/domaincapsdata/qemu_5.0.0-tcg-virt.riscv64.xml
+@@ -154,6 +154,7 @@
+     <async-teardown supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_5.0.0-tcg.x86_64.xml b/tests/domaincapsdata/qemu_5.0.0-tcg.x86_64.xml
+index d69ea76a..5bc87668 100644
+--- a/tests/domaincapsdata/qemu_5.0.0-tcg.x86_64.xml
++++ b/tests/domaincapsdata/qemu_5.0.0-tcg.x86_64.xml
+@@ -271,6 +271,7 @@
+     <async-teardown supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_5.0.0-virt.aarch64.xml b/tests/domaincapsdata/qemu_5.0.0-virt.aarch64.xml
+index 2466dda7..a7955432 100644
+--- a/tests/domaincapsdata/qemu_5.0.0-virt.aarch64.xml
++++ b/tests/domaincapsdata/qemu_5.0.0-virt.aarch64.xml
+@@ -214,6 +214,7 @@
+     <async-teardown supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_5.0.0-virt.riscv64.xml b/tests/domaincapsdata/qemu_5.0.0-virt.riscv64.xml
+index b0e4aafc..09617e26 100644
+--- a/tests/domaincapsdata/qemu_5.0.0-virt.riscv64.xml
++++ b/tests/domaincapsdata/qemu_5.0.0-virt.riscv64.xml
+@@ -157,6 +157,7 @@
+     <async-teardown supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_5.0.0.aarch64.xml b/tests/domaincapsdata/qemu_5.0.0.aarch64.xml
+index 2466dda7..a7955432 100644
+--- a/tests/domaincapsdata/qemu_5.0.0.aarch64.xml
++++ b/tests/domaincapsdata/qemu_5.0.0.aarch64.xml
+@@ -214,6 +214,7 @@
+     <async-teardown supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_5.0.0.ppc64.xml b/tests/domaincapsdata/qemu_5.0.0.ppc64.xml
+index c66d0645..84928251 100644
+--- a/tests/domaincapsdata/qemu_5.0.0.ppc64.xml
++++ b/tests/domaincapsdata/qemu_5.0.0.ppc64.xml
+@@ -176,6 +176,7 @@
+     <async-teardown supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_5.0.0.x86_64.xml b/tests/domaincapsdata/qemu_5.0.0.x86_64.xml
+index c57d4f32..ca788d3c 100644
+--- a/tests/domaincapsdata/qemu_5.0.0.x86_64.xml
++++ b/tests/domaincapsdata/qemu_5.0.0.x86_64.xml
+@@ -326,6 +326,7 @@
+     <async-teardown supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_5.1.0-q35.x86_64.xml b/tests/domaincapsdata/qemu_5.1.0-q35.x86_64.xml
+index f276f0b7..2b8efb9e 100644
+--- a/tests/domaincapsdata/qemu_5.1.0-q35.x86_64.xml
++++ b/tests/domaincapsdata/qemu_5.1.0-q35.x86_64.xml
+@@ -258,6 +258,7 @@
+     <async-teardown supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_5.1.0-tcg.x86_64.xml b/tests/domaincapsdata/qemu_5.1.0-tcg.x86_64.xml
+index eea710a0..6b49c06d 100644
+--- a/tests/domaincapsdata/qemu_5.1.0-tcg.x86_64.xml
++++ b/tests/domaincapsdata/qemu_5.1.0-tcg.x86_64.xml
+@@ -271,6 +271,7 @@
+     <async-teardown supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_5.1.0.sparc.xml b/tests/domaincapsdata/qemu_5.1.0.sparc.xml
+index a471a937..7e5eb5df 100644
+--- a/tests/domaincapsdata/qemu_5.1.0.sparc.xml
++++ b/tests/domaincapsdata/qemu_5.1.0.sparc.xml
+@@ -140,6 +140,7 @@
+     <async-teardown supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_5.1.0.x86_64.xml b/tests/domaincapsdata/qemu_5.1.0.x86_64.xml
+index 56e30cc3..17576e30 100644
+--- a/tests/domaincapsdata/qemu_5.1.0.x86_64.xml
++++ b/tests/domaincapsdata/qemu_5.1.0.x86_64.xml
+@@ -258,6 +258,7 @@
+     <async-teardown supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_5.2.0-q35.x86_64.xml b/tests/domaincapsdata/qemu_5.2.0-q35.x86_64.xml
+index 35bc747d..c653d765 100644
+--- a/tests/domaincapsdata/qemu_5.2.0-q35.x86_64.xml
++++ b/tests/domaincapsdata/qemu_5.2.0-q35.x86_64.xml
+@@ -259,6 +259,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_5.2.0-tcg-virt.riscv64.xml b/tests/domaincapsdata/qemu_5.2.0-tcg-virt.riscv64.xml
+index eaed71b4..c309a3c2 100644
+--- a/tests/domaincapsdata/qemu_5.2.0-tcg-virt.riscv64.xml
++++ b/tests/domaincapsdata/qemu_5.2.0-tcg-virt.riscv64.xml
+@@ -157,6 +157,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_5.2.0-tcg.x86_64.xml b/tests/domaincapsdata/qemu_5.2.0-tcg.x86_64.xml
+index 33b55317..f61cdce6 100644
+--- a/tests/domaincapsdata/qemu_5.2.0-tcg.x86_64.xml
++++ b/tests/domaincapsdata/qemu_5.2.0-tcg.x86_64.xml
+@@ -272,6 +272,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_5.2.0-virt.aarch64.xml b/tests/domaincapsdata/qemu_5.2.0-virt.aarch64.xml
+index a35dd78c..c093dde9 100644
+--- a/tests/domaincapsdata/qemu_5.2.0-virt.aarch64.xml
++++ b/tests/domaincapsdata/qemu_5.2.0-virt.aarch64.xml
+@@ -215,6 +215,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_5.2.0-virt.riscv64.xml b/tests/domaincapsdata/qemu_5.2.0-virt.riscv64.xml
+index 14d936ea..4839e7f0 100644
+--- a/tests/domaincapsdata/qemu_5.2.0-virt.riscv64.xml
++++ b/tests/domaincapsdata/qemu_5.2.0-virt.riscv64.xml
+@@ -160,6 +160,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_5.2.0.aarch64.xml b/tests/domaincapsdata/qemu_5.2.0.aarch64.xml
+index a35dd78c..c093dde9 100644
+--- a/tests/domaincapsdata/qemu_5.2.0.aarch64.xml
++++ b/tests/domaincapsdata/qemu_5.2.0.aarch64.xml
+@@ -215,6 +215,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_5.2.0.ppc64.xml b/tests/domaincapsdata/qemu_5.2.0.ppc64.xml
+index a6fcc39c..bd1e3bfd 100644
+--- a/tests/domaincapsdata/qemu_5.2.0.ppc64.xml
++++ b/tests/domaincapsdata/qemu_5.2.0.ppc64.xml
+@@ -177,6 +177,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_5.2.0.s390x.xml b/tests/domaincapsdata/qemu_5.2.0.s390x.xml
+index 084a221f..ca78cb76 100644
+--- a/tests/domaincapsdata/qemu_5.2.0.s390x.xml
++++ b/tests/domaincapsdata/qemu_5.2.0.s390x.xml
+@@ -278,6 +278,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_5.2.0.x86_64.xml b/tests/domaincapsdata/qemu_5.2.0.x86_64.xml
+index 2889fce1..c960d52b 100644
+--- a/tests/domaincapsdata/qemu_5.2.0.x86_64.xml
++++ b/tests/domaincapsdata/qemu_5.2.0.x86_64.xml
+@@ -259,6 +259,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_6.0.0-q35.x86_64.xml b/tests/domaincapsdata/qemu_6.0.0-q35.x86_64.xml
+index 5bc2bdd1..a4367817 100644
+--- a/tests/domaincapsdata/qemu_6.0.0-q35.x86_64.xml
++++ b/tests/domaincapsdata/qemu_6.0.0-q35.x86_64.xml
+@@ -266,6 +266,7 @@
+       <maxESGuests>450</maxESGuests>
+     </sev>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='yes'>
+       <enum name='sectype'>
+         <value>sev</value>
+diff --git a/tests/domaincapsdata/qemu_6.0.0-tcg.x86_64.xml b/tests/domaincapsdata/qemu_6.0.0-tcg.x86_64.xml
+index a39f777e..3d414601 100644
+--- a/tests/domaincapsdata/qemu_6.0.0-tcg.x86_64.xml
++++ b/tests/domaincapsdata/qemu_6.0.0-tcg.x86_64.xml
+@@ -280,6 +280,7 @@
+       <maxESGuests>450</maxESGuests>
+     </sev>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='yes'>
+       <enum name='sectype'>
+         <value>sev</value>
+diff --git a/tests/domaincapsdata/qemu_6.0.0-virt.aarch64.xml b/tests/domaincapsdata/qemu_6.0.0-virt.aarch64.xml
+index 780436ce..152682fe 100644
+--- a/tests/domaincapsdata/qemu_6.0.0-virt.aarch64.xml
++++ b/tests/domaincapsdata/qemu_6.0.0-virt.aarch64.xml
+@@ -217,6 +217,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_6.0.0.aarch64.xml b/tests/domaincapsdata/qemu_6.0.0.aarch64.xml
+index 780436ce..152682fe 100644
+--- a/tests/domaincapsdata/qemu_6.0.0.aarch64.xml
++++ b/tests/domaincapsdata/qemu_6.0.0.aarch64.xml
+@@ -217,6 +217,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_6.0.0.s390x.xml b/tests/domaincapsdata/qemu_6.0.0.s390x.xml
+index 2bc02dd4..ef712c09 100644
+--- a/tests/domaincapsdata/qemu_6.0.0.s390x.xml
++++ b/tests/domaincapsdata/qemu_6.0.0.s390x.xml
+@@ -279,6 +279,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='yes'>
+       <enum name='sectype'>
+         <value>s390-pv</value>
+diff --git a/tests/domaincapsdata/qemu_6.0.0.x86_64.xml b/tests/domaincapsdata/qemu_6.0.0.x86_64.xml
+index 0c322b11..1d27c012 100644
+--- a/tests/domaincapsdata/qemu_6.0.0.x86_64.xml
++++ b/tests/domaincapsdata/qemu_6.0.0.x86_64.xml
+@@ -266,6 +266,7 @@
+       <maxESGuests>450</maxESGuests>
+     </sev>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='yes'>
+       <enum name='sectype'>
+         <value>sev</value>
+diff --git a/tests/domaincapsdata/qemu_6.1.0-q35.x86_64.xml b/tests/domaincapsdata/qemu_6.1.0-q35.x86_64.xml
+index b5f488d5..5f64467a 100644
+--- a/tests/domaincapsdata/qemu_6.1.0-q35.x86_64.xml
++++ b/tests/domaincapsdata/qemu_6.1.0-q35.x86_64.xml
+@@ -262,6 +262,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_6.1.0-tcg.x86_64.xml b/tests/domaincapsdata/qemu_6.1.0-tcg.x86_64.xml
+index 3137894a..ab50f631 100644
+--- a/tests/domaincapsdata/qemu_6.1.0-tcg.x86_64.xml
++++ b/tests/domaincapsdata/qemu_6.1.0-tcg.x86_64.xml
+@@ -275,6 +275,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_6.1.0.x86_64.xml b/tests/domaincapsdata/qemu_6.1.0.x86_64.xml
+index a99dccf8..49f13ed4 100644
+--- a/tests/domaincapsdata/qemu_6.1.0.x86_64.xml
++++ b/tests/domaincapsdata/qemu_6.1.0.x86_64.xml
+@@ -262,6 +262,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_6.2.0-q35.x86_64.xml b/tests/domaincapsdata/qemu_6.2.0-q35.x86_64.xml
+index 2326871d..fd0bdefc 100644
+--- a/tests/domaincapsdata/qemu_6.2.0-q35.x86_64.xml
++++ b/tests/domaincapsdata/qemu_6.2.0-q35.x86_64.xml
+@@ -262,6 +262,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_6.2.0-tcg.x86_64.xml b/tests/domaincapsdata/qemu_6.2.0-tcg.x86_64.xml
+index 4270ba0b..820e7c08 100644
+--- a/tests/domaincapsdata/qemu_6.2.0-tcg.x86_64.xml
++++ b/tests/domaincapsdata/qemu_6.2.0-tcg.x86_64.xml
+@@ -277,6 +277,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_6.2.0-virt.aarch64.xml b/tests/domaincapsdata/qemu_6.2.0-virt.aarch64.xml
+index d0903aac..44868113 100644
+--- a/tests/domaincapsdata/qemu_6.2.0-virt.aarch64.xml
++++ b/tests/domaincapsdata/qemu_6.2.0-virt.aarch64.xml
+@@ -224,6 +224,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_6.2.0.aarch64.xml b/tests/domaincapsdata/qemu_6.2.0.aarch64.xml
+index d0903aac..44868113 100644
+--- a/tests/domaincapsdata/qemu_6.2.0.aarch64.xml
++++ b/tests/domaincapsdata/qemu_6.2.0.aarch64.xml
+@@ -224,6 +224,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_6.2.0.ppc64.xml b/tests/domaincapsdata/qemu_6.2.0.ppc64.xml
+index fe62364d..7a2f6b5e 100644
+--- a/tests/domaincapsdata/qemu_6.2.0.ppc64.xml
++++ b/tests/domaincapsdata/qemu_6.2.0.ppc64.xml
+@@ -176,6 +176,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_6.2.0.x86_64.xml b/tests/domaincapsdata/qemu_6.2.0.x86_64.xml
+index 63ddcaec..3357dc26 100644
+--- a/tests/domaincapsdata/qemu_6.2.0.x86_64.xml
++++ b/tests/domaincapsdata/qemu_6.2.0.x86_64.xml
+@@ -262,6 +262,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_7.0.0-hvf.aarch64+hvf.xml b/tests/domaincapsdata/qemu_7.0.0-hvf.aarch64+hvf.xml
+index 32eee7ea..d4b5ef30 100644
+--- a/tests/domaincapsdata/qemu_7.0.0-hvf.aarch64+hvf.xml
++++ b/tests/domaincapsdata/qemu_7.0.0-hvf.aarch64+hvf.xml
+@@ -178,6 +178,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_7.0.0-q35.x86_64.xml b/tests/domaincapsdata/qemu_7.0.0-q35.x86_64.xml
+index 83c62a11..5aa10bed 100644
+--- a/tests/domaincapsdata/qemu_7.0.0-q35.x86_64.xml
++++ b/tests/domaincapsdata/qemu_7.0.0-q35.x86_64.xml
+@@ -272,6 +272,7 @@
+         <section node='1' size='262144' unit='KiB'/>
+       </sections>
+     </sgx>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_7.0.0-tcg.x86_64.xml b/tests/domaincapsdata/qemu_7.0.0-tcg.x86_64.xml
+index 00adacd1..6b00d2a2 100644
+--- a/tests/domaincapsdata/qemu_7.0.0-tcg.x86_64.xml
++++ b/tests/domaincapsdata/qemu_7.0.0-tcg.x86_64.xml
+@@ -287,6 +287,7 @@
+         <section node='1' size='262144' unit='KiB'/>
+       </sections>
+     </sgx>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_7.0.0-virt.aarch64.xml b/tests/domaincapsdata/qemu_7.0.0-virt.aarch64.xml
+index 216e3999..661c8160 100644
+--- a/tests/domaincapsdata/qemu_7.0.0-virt.aarch64.xml
++++ b/tests/domaincapsdata/qemu_7.0.0-virt.aarch64.xml
+@@ -223,6 +223,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_7.0.0.aarch64.xml b/tests/domaincapsdata/qemu_7.0.0.aarch64.xml
+index 216e3999..661c8160 100644
+--- a/tests/domaincapsdata/qemu_7.0.0.aarch64.xml
++++ b/tests/domaincapsdata/qemu_7.0.0.aarch64.xml
+@@ -223,6 +223,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_7.0.0.ppc64.xml b/tests/domaincapsdata/qemu_7.0.0.ppc64.xml
+index e0fda8fc..544662cb 100644
+--- a/tests/domaincapsdata/qemu_7.0.0.ppc64.xml
++++ b/tests/domaincapsdata/qemu_7.0.0.ppc64.xml
+@@ -181,6 +181,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_7.0.0.x86_64.xml b/tests/domaincapsdata/qemu_7.0.0.x86_64.xml
+index 97e38888..d24320a9 100644
+--- a/tests/domaincapsdata/qemu_7.0.0.x86_64.xml
++++ b/tests/domaincapsdata/qemu_7.0.0.x86_64.xml
+@@ -272,6 +272,7 @@
+         <section node='1' size='262144' unit='KiB'/>
+       </sections>
+     </sgx>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_7.1.0-q35.x86_64.xml b/tests/domaincapsdata/qemu_7.1.0-q35.x86_64.xml
+index 1b55b9b4..8cbc94b5 100644
+--- a/tests/domaincapsdata/qemu_7.1.0-q35.x86_64.xml
++++ b/tests/domaincapsdata/qemu_7.1.0-q35.x86_64.xml
+@@ -262,6 +262,7 @@
+     <ps2 supported='yes'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_7.1.0-tcg.x86_64.xml b/tests/domaincapsdata/qemu_7.1.0-tcg.x86_64.xml
+index 37697928..64d7433c 100644
+--- a/tests/domaincapsdata/qemu_7.1.0-tcg.x86_64.xml
++++ b/tests/domaincapsdata/qemu_7.1.0-tcg.x86_64.xml
+@@ -276,6 +276,7 @@
+     <ps2 supported='yes'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_7.1.0.ppc64.xml b/tests/domaincapsdata/qemu_7.1.0.ppc64.xml
+index bbdf8a60..5e770f07 100644
+--- a/tests/domaincapsdata/qemu_7.1.0.ppc64.xml
++++ b/tests/domaincapsdata/qemu_7.1.0.ppc64.xml
+@@ -174,6 +174,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_7.1.0.x86_64.xml b/tests/domaincapsdata/qemu_7.1.0.x86_64.xml
+index 9d5ff18c..d839197d 100644
+--- a/tests/domaincapsdata/qemu_7.1.0.x86_64.xml
++++ b/tests/domaincapsdata/qemu_7.1.0.x86_64.xml
+@@ -262,6 +262,7 @@
+     <ps2 supported='yes'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_7.2.0-hvf.x86_64+hvf.xml b/tests/domaincapsdata/qemu_7.2.0-hvf.x86_64+hvf.xml
+index 091735d8..13385e46 100644
+--- a/tests/domaincapsdata/qemu_7.2.0-hvf.x86_64+hvf.xml
++++ b/tests/domaincapsdata/qemu_7.2.0-hvf.x86_64+hvf.xml
+@@ -186,6 +186,7 @@
+     <ps2 supported='yes'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_7.2.0-q35.x86_64.xml b/tests/domaincapsdata/qemu_7.2.0-q35.x86_64.xml
+index 73475e49..2d407c92 100644
+--- a/tests/domaincapsdata/qemu_7.2.0-q35.x86_64.xml
++++ b/tests/domaincapsdata/qemu_7.2.0-q35.x86_64.xml
+@@ -269,6 +269,7 @@
+     <ps2 supported='yes'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_7.2.0-tcg.x86_64+hvf.xml b/tests/domaincapsdata/qemu_7.2.0-tcg.x86_64+hvf.xml
+index 38fedd6c..a8d7816d 100644
+--- a/tests/domaincapsdata/qemu_7.2.0-tcg.x86_64+hvf.xml
++++ b/tests/domaincapsdata/qemu_7.2.0-tcg.x86_64+hvf.xml
+@@ -267,6 +267,7 @@
+     <ps2 supported='yes'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_7.2.0-tcg.x86_64.xml b/tests/domaincapsdata/qemu_7.2.0-tcg.x86_64.xml
+index 38fedd6c..a8d7816d 100644
+--- a/tests/domaincapsdata/qemu_7.2.0-tcg.x86_64.xml
++++ b/tests/domaincapsdata/qemu_7.2.0-tcg.x86_64.xml
+@@ -267,6 +267,7 @@
+     <ps2 supported='yes'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_7.2.0.ppc.xml b/tests/domaincapsdata/qemu_7.2.0.ppc.xml
+index 416ebc6f..b4908ce2 100644
+--- a/tests/domaincapsdata/qemu_7.2.0.ppc.xml
++++ b/tests/domaincapsdata/qemu_7.2.0.ppc.xml
+@@ -161,6 +161,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_7.2.0.x86_64.xml b/tests/domaincapsdata/qemu_7.2.0.x86_64.xml
+index b8b2aada..58f333fc 100644
+--- a/tests/domaincapsdata/qemu_7.2.0.x86_64.xml
++++ b/tests/domaincapsdata/qemu_7.2.0.x86_64.xml
+@@ -269,6 +269,7 @@
+     <ps2 supported='yes'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_8.0.0-q35.x86_64.xml b/tests/domaincapsdata/qemu_8.0.0-q35.x86_64.xml
+index c7c118d5..d70e32c0 100644
+--- a/tests/domaincapsdata/qemu_8.0.0-q35.x86_64.xml
++++ b/tests/domaincapsdata/qemu_8.0.0-q35.x86_64.xml
+@@ -270,6 +270,7 @@
+     <ps2 supported='yes'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <hyperv supported='yes'>
+       <enum name='features'>
+         <value>relaxed</value>
+diff --git a/tests/domaincapsdata/qemu_8.0.0-tcg-virt.riscv64.xml b/tests/domaincapsdata/qemu_8.0.0-tcg-virt.riscv64.xml
+index af787b8b..7da008be 100644
+--- a/tests/domaincapsdata/qemu_8.0.0-tcg-virt.riscv64.xml
++++ b/tests/domaincapsdata/qemu_8.0.0-tcg-virt.riscv64.xml
+@@ -164,6 +164,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_8.0.0-tcg.x86_64.xml b/tests/domaincapsdata/qemu_8.0.0-tcg.x86_64.xml
+index ab81714c..2e8f86bc 100644
+--- a/tests/domaincapsdata/qemu_8.0.0-tcg.x86_64.xml
++++ b/tests/domaincapsdata/qemu_8.0.0-tcg.x86_64.xml
+@@ -272,6 +272,7 @@
+     <ps2 supported='yes'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <hyperv supported='yes'>
+       <enum name='features'>
+         <value>relaxed</value>
+diff --git a/tests/domaincapsdata/qemu_8.0.0-virt.riscv64.xml b/tests/domaincapsdata/qemu_8.0.0-virt.riscv64.xml
+index 0e3e9b81..81a2855c 100644
+--- a/tests/domaincapsdata/qemu_8.0.0-virt.riscv64.xml
++++ b/tests/domaincapsdata/qemu_8.0.0-virt.riscv64.xml
+@@ -167,6 +167,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_8.0.0.x86_64.xml b/tests/domaincapsdata/qemu_8.0.0.x86_64.xml
+index ad9eaf54..895fb133 100644
+--- a/tests/domaincapsdata/qemu_8.0.0.x86_64.xml
++++ b/tests/domaincapsdata/qemu_8.0.0.x86_64.xml
+@@ -270,6 +270,7 @@
+     <ps2 supported='yes'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <hyperv supported='yes'>
+       <enum name='features'>
+         <value>relaxed</value>
+diff --git a/tests/domaincapsdata/qemu_8.1.0-q35.x86_64.xml b/tests/domaincapsdata/qemu_8.1.0-q35.x86_64.xml
+index aa01168a..9f3fdcae 100644
+--- a/tests/domaincapsdata/qemu_8.1.0-q35.x86_64.xml
++++ b/tests/domaincapsdata/qemu_8.1.0-q35.x86_64.xml
+@@ -273,6 +273,7 @@
+     <ps2 supported='yes'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <hyperv supported='yes'>
+       <enum name='features'>
+         <value>relaxed</value>
+diff --git a/tests/domaincapsdata/qemu_8.1.0-tcg.x86_64.xml b/tests/domaincapsdata/qemu_8.1.0-tcg.x86_64.xml
+index 8e33506a..c4c1e3d1 100644
+--- a/tests/domaincapsdata/qemu_8.1.0-tcg.x86_64.xml
++++ b/tests/domaincapsdata/qemu_8.1.0-tcg.x86_64.xml
+@@ -274,6 +274,7 @@
+     <ps2 supported='yes'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <hyperv supported='yes'>
+       <enum name='features'>
+         <value>relaxed</value>
+diff --git a/tests/domaincapsdata/qemu_8.1.0.s390x.xml b/tests/domaincapsdata/qemu_8.1.0.s390x.xml
+index 92fa89f0..e70e75e2 100644
+--- a/tests/domaincapsdata/qemu_8.1.0.s390x.xml
++++ b/tests/domaincapsdata/qemu_8.1.0.s390x.xml
+@@ -275,6 +275,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='yes'>
+       <enum name='sectype'>
+         <value>s390-pv</value>
+diff --git a/tests/domaincapsdata/qemu_8.1.0.x86_64.xml b/tests/domaincapsdata/qemu_8.1.0.x86_64.xml
+index 532a9b2d..57b7eea8 100644
+--- a/tests/domaincapsdata/qemu_8.1.0.x86_64.xml
++++ b/tests/domaincapsdata/qemu_8.1.0.x86_64.xml
+@@ -273,6 +273,7 @@
+     <ps2 supported='yes'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <hyperv supported='yes'>
+       <enum name='features'>
+         <value>relaxed</value>
+diff --git a/tests/domaincapsdata/qemu_8.2.0-q35.x86_64.xml b/tests/domaincapsdata/qemu_8.2.0-q35.x86_64.xml
+index cebc4e01..cce8fcaf 100644
+--- a/tests/domaincapsdata/qemu_8.2.0-q35.x86_64.xml
++++ b/tests/domaincapsdata/qemu_8.2.0-q35.x86_64.xml
+@@ -275,6 +275,7 @@
+     <ps2 supported='yes'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <hyperv supported='yes'>
+       <enum name='features'>
+         <value>relaxed</value>
+diff --git a/tests/domaincapsdata/qemu_8.2.0-tcg-virt.loongarch64.xml b/tests/domaincapsdata/qemu_8.2.0-tcg-virt.loongarch64.xml
+index 3917ce61..728ed3f9 100644
+--- a/tests/domaincapsdata/qemu_8.2.0-tcg-virt.loongarch64.xml
++++ b/tests/domaincapsdata/qemu_8.2.0-tcg-virt.loongarch64.xml
+@@ -168,6 +168,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_8.2.0-tcg.x86_64.xml b/tests/domaincapsdata/qemu_8.2.0-tcg.x86_64.xml
+index a68b8a6f..16dddea1 100644
+--- a/tests/domaincapsdata/qemu_8.2.0-tcg.x86_64.xml
++++ b/tests/domaincapsdata/qemu_8.2.0-tcg.x86_64.xml
+@@ -274,6 +274,7 @@
+     <ps2 supported='yes'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <hyperv supported='yes'>
+       <enum name='features'>
+         <value>relaxed</value>
+diff --git a/tests/domaincapsdata/qemu_8.2.0-virt.aarch64.xml b/tests/domaincapsdata/qemu_8.2.0-virt.aarch64.xml
+index 2f661b7e..9013e527 100644
+--- a/tests/domaincapsdata/qemu_8.2.0-virt.aarch64.xml
++++ b/tests/domaincapsdata/qemu_8.2.0-virt.aarch64.xml
+@@ -230,6 +230,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_8.2.0-virt.loongarch64.xml b/tests/domaincapsdata/qemu_8.2.0-virt.loongarch64.xml
+index edddb6d8..55468c65 100644
+--- a/tests/domaincapsdata/qemu_8.2.0-virt.loongarch64.xml
++++ b/tests/domaincapsdata/qemu_8.2.0-virt.loongarch64.xml
+@@ -172,6 +172,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_8.2.0.aarch64.xml b/tests/domaincapsdata/qemu_8.2.0.aarch64.xml
+index 2f661b7e..9013e527 100644
+--- a/tests/domaincapsdata/qemu_8.2.0.aarch64.xml
++++ b/tests/domaincapsdata/qemu_8.2.0.aarch64.xml
+@@ -230,6 +230,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_8.2.0.armv7l.xml b/tests/domaincapsdata/qemu_8.2.0.armv7l.xml
+index fb0f7665..862ea3b4 100644
+--- a/tests/domaincapsdata/qemu_8.2.0.armv7l.xml
++++ b/tests/domaincapsdata/qemu_8.2.0.armv7l.xml
+@@ -178,6 +178,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_8.2.0.s390x.xml b/tests/domaincapsdata/qemu_8.2.0.s390x.xml
+index cc8bbec0..0d1d54f8 100644
+--- a/tests/domaincapsdata/qemu_8.2.0.s390x.xml
++++ b/tests/domaincapsdata/qemu_8.2.0.s390x.xml
+@@ -275,6 +275,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='yes'>
+       <enum name='sectype'>
+         <value>s390-pv</value>
+diff --git a/tests/domaincapsdata/qemu_8.2.0.x86_64.xml b/tests/domaincapsdata/qemu_8.2.0.x86_64.xml
+index 0bd89504..2918526e 100644
+--- a/tests/domaincapsdata/qemu_8.2.0.x86_64.xml
++++ b/tests/domaincapsdata/qemu_8.2.0.x86_64.xml
+@@ -275,6 +275,7 @@
+     <ps2 supported='yes'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <hyperv supported='yes'>
+       <enum name='features'>
+         <value>relaxed</value>
+diff --git a/tests/domaincapsdata/qemu_9.0.0-q35.x86_64.xml b/tests/domaincapsdata/qemu_9.0.0-q35.x86_64.xml
+index b9a21549..b614b6b7 100644
+--- a/tests/domaincapsdata/qemu_9.0.0-q35.x86_64.xml
++++ b/tests/domaincapsdata/qemu_9.0.0-q35.x86_64.xml
+@@ -275,6 +275,7 @@
+     <ps2 supported='yes'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <hyperv supported='yes'>
+       <enum name='features'>
+         <value>relaxed</value>
+diff --git a/tests/domaincapsdata/qemu_9.0.0-tcg.x86_64.xml b/tests/domaincapsdata/qemu_9.0.0-tcg.x86_64.xml
+index 25bf1d84..f917b160 100644
+--- a/tests/domaincapsdata/qemu_9.0.0-tcg.x86_64.xml
++++ b/tests/domaincapsdata/qemu_9.0.0-tcg.x86_64.xml
+@@ -276,6 +276,7 @@
+     <ps2 supported='yes'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <hyperv supported='yes'>
+       <enum name='features'>
+         <value>relaxed</value>
+diff --git a/tests/domaincapsdata/qemu_9.0.0.sparc.xml b/tests/domaincapsdata/qemu_9.0.0.sparc.xml
+index ab5c3dc4..0cca40dd 100644
+--- a/tests/domaincapsdata/qemu_9.0.0.sparc.xml
++++ b/tests/domaincapsdata/qemu_9.0.0.sparc.xml
+@@ -140,6 +140,7 @@
+     <ps2 supported='no'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <launchSecurity supported='no'/>
+   </features>
+ </domainCapabilities>
+diff --git a/tests/domaincapsdata/qemu_9.0.0.x86_64.xml b/tests/domaincapsdata/qemu_9.0.0.x86_64.xml
+index f785e83f..e0d0220c 100644
+--- a/tests/domaincapsdata/qemu_9.0.0.x86_64.xml
++++ b/tests/domaincapsdata/qemu_9.0.0.x86_64.xml
+@@ -275,6 +275,7 @@
+     <ps2 supported='yes'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <hyperv supported='yes'>
+       <enum name='features'>
+         <value>relaxed</value>
+diff --git a/tests/domaincapsdata/qemu_9.1.0-q35.x86_64.xml b/tests/domaincapsdata/qemu_9.1.0-q35.x86_64.xml
+index ef364621..14f6898c 100644
+--- a/tests/domaincapsdata/qemu_9.1.0-q35.x86_64.xml
++++ b/tests/domaincapsdata/qemu_9.1.0-q35.x86_64.xml
+@@ -279,6 +279,7 @@
+     <ps2 supported='yes'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <hyperv supported='yes'>
+       <enum name='features'>
+         <value>relaxed</value>
+diff --git a/tests/domaincapsdata/qemu_9.1.0-tcg.x86_64.xml b/tests/domaincapsdata/qemu_9.1.0-tcg.x86_64.xml
+index 2415f76f..be36933a 100644
+--- a/tests/domaincapsdata/qemu_9.1.0-tcg.x86_64.xml
++++ b/tests/domaincapsdata/qemu_9.1.0-tcg.x86_64.xml
+@@ -275,6 +275,7 @@
+     <ps2 supported='yes'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <hyperv supported='yes'>
+       <enum name='features'>
+         <value>relaxed</value>
+diff --git a/tests/domaincapsdata/qemu_9.1.0.x86_64.xml b/tests/domaincapsdata/qemu_9.1.0.x86_64.xml
+index 8cba35fb..9c669143 100644
+--- a/tests/domaincapsdata/qemu_9.1.0.x86_64.xml
++++ b/tests/domaincapsdata/qemu_9.1.0.x86_64.xml
+@@ -279,6 +279,7 @@
+     <ps2 supported='yes'/>
+     <sev supported='no'/>
+     <sgx supported='no'/>
++    <cca supported='no'/>
+     <hyperv supported='yes'>
+       <enum name='features'>
+         <value>relaxed</value>
+-- 
+2.51.0
+

--- a/debian/patches/backport/0003-src-Add-ARM-CCA-support-in-domain-schema.patch
+++ b/debian/patches/backport/0003-src-Add-ARM-CCA-support-in-domain-schema.patch
@@ -1,0 +1,324 @@
+From 8127449254052bc2509a58d4e3be3b7223dbb694 Mon Sep 17 00:00:00 2001
+From: WangYuli <wangyuli@aosc.io>
+Date: Fri, 5 Dec 2025 13:05:21 +0800
+Subject: [PATCH 3/3] src: Add ARM CCA support in domain schema
+
+bugzilla:https://gitee.com/openeuler/libvirt/issues/ICU4UF?from=project-issue
+reference:https://patchew.org/Libvirt/20250612071418.2926384-1-fj1078ii@aa.jp.fujitsu.com/
+
+--------------------------------
+
+- Add ARM CCA support in domain schema files.
+
+Signed-off-by: Kazuhiro Abe <fj1078ii@aa.jp.fujitsu.com>
+Signed-off-by: rpm-build <rpm-build>
+Signed-off-by: WangYuli <wangyuli@aosc.io>
+---
+ src/conf/schemas/domaincaps.rng   |  36 ++++++++++
+ src/conf/schemas/domaincommon.rng |  26 +++++++
+ src/qemu/qemu_capabilities.c      | 113 ++++++++++++++++++++++++++++++
+ src/qemu/qemu_capabilities.h      |   3 +
+ 4 files changed, 178 insertions(+)
+
+diff --git a/src/conf/schemas/domaincaps.rng b/src/conf/schemas/domaincaps.rng
+index f9b87c8a..be6f0820 100644
+--- a/src/conf/schemas/domaincaps.rng
++++ b/src/conf/schemas/domaincaps.rng
+@@ -334,6 +334,9 @@
+       <optional>
+         <ref name="sgx"/>
+       </optional>
++      <optional>
++        <ref name="cca"/>
++      </optional>
+       <optional>
+         <ref name="hyperv"/>
+       </optional>
+@@ -452,6 +455,39 @@
+     </element>
+   </define>
+ 
++  <define name="cca">
++    <element name="cca">
++      <ref name="supported"/>
++      <interleave>
++        <optional>
++          <attribute name="measurement-log">
++            <ref name="virYesNo"/>
++          </attribute>
++        </optional>
++        <optional>
++          <element name="enum">
++            <attribute name="name">
++              <value>measurement-algo</value>
++            </attribute>
++            <group>
++              <element name="value">
++                <value>sha256</value>
++              </element>
++              <element name="value">
++                <value>sha512</value>
++              </element>
++            </group>
++          </element>
++        </optional>
++        <optional>
++          <element name="personalization-value">
++            <text/>
++          </element>
++        </optional>
++      </interleave>
++    </element>
++  </define>
++
+   <define name="hyperv">
+     <element name="hyperv">
+       <ref name="supported"/>
+diff --git a/src/conf/schemas/domaincommon.rng b/src/conf/schemas/domaincommon.rng
+index efb5f00d..b4c86cfe 100644
+--- a/src/conf/schemas/domaincommon.rng
++++ b/src/conf/schemas/domaincommon.rng
+@@ -523,6 +523,9 @@
+             <value>s390-pv</value>
+           </attribute>
+         </group>
++        <group>
++          <ref name="launchSecurityCCA"/>
++        </group>
+       </choice>
+     </element>
+   </define>
+@@ -618,6 +621,29 @@
+       </optional>
+     </interleave>
+   </define>
++
++  <define name="launchSecurityCCA">
++    <attribute name="type">
++      <value>cca</value>
++    </attribute>
++    <interleave>
++      <optional>
++        <attribute name="measurement-log">
++          <ref name="virYesNo"/>
++        </attribute>
++      </optional>
++      <optional>
++        <element name="measurement-algo">
++          <data type="string"/>
++        </element>
++      </optional>
++      <optional>
++        <element name="personalization-value">
++          <data type="string"/>
++        </element>
++      </optional>
++    </interleave>
++  </define>
+   <!--
+       Enable or disable perf events for the domain. For each
+       of the events the following rules apply:
+diff --git a/src/qemu/qemu_capabilities.c b/src/qemu/qemu_capabilities.c
+index 16adfa55..00623f78 100644
+--- a/src/qemu/qemu_capabilities.c
++++ b/src/qemu/qemu_capabilities.c
+@@ -1946,6 +1946,34 @@ virQEMUCapsSGXInfoCopy(virSGXCapability **dst,
+ }
+ 
+ 
++static void
++virQEMUCapsCCAInfoCopy(virCCACapability **dst,
++                       virCCACapability *src)
++{
++    g_autoptr(virCCACapability) tmp = NULL;
++    size_t i;
++
++    if (!src) {
++        *dst = NULL;
++        return;
++    }
++
++    tmp = g_new0(virCCACapability, 1);
++
++    tmp->nCcaMeasurementAlgo = src->nCcaMeasurementAlgo;
++
++    if (tmp->nCcaMeasurementAlgo != 0) {
++        tmp->ccaMeasurementAlgo = g_new0(char *, tmp->nCcaMeasurementAlgo);
++
++        for (i = 0; i < tmp->nCcaMeasurementAlgo; i++) {
++            tmp->ccaMeasurementAlgo[i] = g_strdup(src->ccaMeasurementAlgo[i]);
++        }
++    }
++
++    *dst = g_steal_pointer(&tmp);
++}
++
++
+ static void
+ virQEMUCapsAccelCopyMachineTypes(virQEMUCapsAccel *dst,
+                                  virQEMUCapsAccel *src)
+@@ -2021,6 +2049,9 @@ virQEMUCaps *virQEMUCapsNewCopy(virQEMUCaps *qemuCaps)
+     if (virQEMUCapsGet(qemuCaps, QEMU_CAPS_SGX_EPC))
+         virQEMUCapsSGXInfoCopy(&ret->sgxCapabilities, qemuCaps->sgxCapabilities);
+ 
++    if (virQEMUCapsGet(qemuCaps, QEMU_CAPS_CCA_GUEST))
++        virQEMUCapsCCAInfoCopy(&ret->ccaCapabilities, qemuCaps->ccaCapabilities);
++
+     ret->hypervCapabilities = g_memdup(qemuCaps->hypervCapabilities,
+                                        sizeof(virDomainCapsFeatureHyperv));
+ 
+@@ -2619,6 +2650,13 @@ virQEMUCapsGetSGXCapabilities(virQEMUCaps *qemuCaps)
+ }
+ 
+ 
++virCCACapability *
++virQEMUCapsGetCCACapabilities(virQEMUCaps *qemuCaps)
++{
++    return qemuCaps->ccaCapabilities;
++}
++
++
+ static int
+ virQEMUCapsProbeQMPObjectTypes(virQEMUCaps *qemuCaps,
+                                qemuMonitor *mon)
+@@ -4422,6 +4460,38 @@ virQEMUCapsParseSGXInfo(virQEMUCaps *qemuCaps,
+ }
+ 
+ 
++static int
++virQEMUCapsParseCCAInfo(virQEMUCaps *qemuCaps,
++                        xmlXPathContextPtr ctxt)
++{
++    g_autofree xmlNodePtr *nodes = NULL;
++    size_t i;
++    int n;
++
++    if ((n = virXPathNodeSet("./cca", ctxt, &nodes)) < 0)
++        return -1;
++
++    if (n > 0) {
++        g_autoptr(virCCACapability) tmp = g_new0(virCCACapability, 1);
++        tmp->ccaMeasurementAlgo = g_new0(char *, n);
++
++        for (i = 0; i < n; i++) {
++            char *malgo = NULL;
++            if (!(malgo = virXMLPropString(nodes[i], "measurement-algo"))) {
++                virReportError(VIR_ERR_INTERNAL_ERROR, "%s",
++                               _("missing CCA measurement-algo in QEMU capabilities cache"));
++                return -1;
++            }
++
++            tmp->ccaMeasurementAlgo[i] = g_strdup(malgo);
++        }
++        tmp->nCcaMeasurementAlgo = n;
++        qemuCaps->ccaCapabilities = g_steal_pointer(&tmp);
++    }
++    return 0;
++}
++
++
+ static int
+ virQEMUCapsParseHypervCapabilities(virQEMUCaps *qemuCaps,
+                                    xmlXPathContextPtr ctxt)
+@@ -4742,6 +4812,9 @@ virQEMUCapsLoadCache(virArch hostArch,
+     if (virQEMUCapsParseSGXInfo(qemuCaps, ctxt) < 0)
+         return -1;
+ 
++    if (virQEMUCapsParseCCAInfo(qemuCaps, ctxt) < 0)
++        return -1;
++
+     if (virQEMUCapsParseHypervCapabilities(qemuCaps, ctxt) < 0)
+         return -1;
+ 
+@@ -4970,6 +5043,23 @@ virQEMUCapsFormatSGXInfo(virQEMUCaps *qemuCaps,
+ }
+ 
+ 
++static void
++virQEMUCapsFormatCCAInfo(virQEMUCaps *qemuCaps, virBuffer *buf)
++{
++    virCCACapability *cca = virQEMUCapsGetCCACapabilities(qemuCaps);
++    size_t i;
++    size_t n;
++
++    n = cca->nCcaMeasurementAlgo;
++
++    if (n != 0) {
++        for (i = 0; i < n; i++) {
++            virBufferAsprintf(buf, "<cca measurement-algo='%s'/>\n", cca->ccaMeasurementAlgo[i]);
++        }
++    }
++}
++
++
+ static void
+ virQEMUCapsFormatHypervCapabilities(virQEMUCaps *qemuCaps,
+                                     virBuffer *buf)
+@@ -5078,6 +5168,9 @@ virQEMUCapsFormatCache(virQEMUCaps *qemuCaps)
+     if (qemuCaps->sgxCapabilities)
+         virQEMUCapsFormatSGXInfo(qemuCaps, &buf);
+ 
++    if (qemuCaps->ccaCapabilities)
++        virQEMUCapsFormatCCAInfo(qemuCaps, &buf);
++
+     if (qemuCaps->hypervCapabilities)
+         virQEMUCapsFormatHypervCapabilities(qemuCaps, &buf);
+ 
+@@ -6604,6 +6697,8 @@ virQEMUCapsFillDomainLaunchSecurity(virQEMUCaps *qemuCaps,
+     if (virQEMUCapsGet(qemuCaps, QEMU_CAPS_S390_PV_GUEST) &&
+         virQEMUCapsGet(qemuCaps, QEMU_CAPS_MACHINE_CONFIDENTAL_GUEST_SUPPORT))
+         VIR_DOMAIN_CAPS_ENUM_SET(launchSecurity->sectype, VIR_DOMAIN_LAUNCH_SECURITY_PV);
++    if (virQEMUCapsGet(qemuCaps, QEMU_CAPS_CCA_GUEST))
++        VIR_DOMAIN_CAPS_ENUM_SET(launchSecurity->sectype, VIR_DOMAIN_LAUNCH_SECURITY_CCA);
+ 
+     if (launchSecurity->sectype.values == 0) {
+         launchSecurity->supported = VIR_TRISTATE_BOOL_NO;
+@@ -6772,6 +6867,23 @@ virQEMUCapsFillDomainFeatureSGXCaps(virQEMUCaps *qemuCaps,
+ }
+ 
+ 
++/**
++ * virQEMUCapsFillDomainFeatureCCACaps:
++ * @qemuCaps: QEMU capabilities
++ * @domCaps: domain capabilities
++ *
++ * Take the information about CCA capabilities that has been obtained
++ * using the 'query-cca-capabilities' QMP command and stored in @qemuCaps
++ * and convert it to a form suitable for @domCaps.
++ */
++static void
++virQEMUCapsFillDomainFeatureCCACaps(virQEMUCaps *qemuCaps,
++                                    virDomainCaps *domCaps)
++{
++    virQEMUCapsCCAInfoCopy(&domCaps->cca, qemuCaps->ccaCapabilities);
++}
++
++
+ static void
+ virQEMUCapsFillDomainFeatureHypervCaps(virQEMUCaps *qemuCaps,
+                                        virDomainCaps *domCaps)
+@@ -6841,6 +6953,7 @@ virQEMUCapsFillDomainCaps(virQEMUCaps *qemuCaps,
+     virQEMUCapsFillDomainFeatureS390PVCaps(qemuCaps, domCaps);
+     virQEMUCapsFillDomainFeaturePS2Caps(qemuCaps, domCaps);
+     virQEMUCapsFillDomainFeatureSGXCaps(qemuCaps, domCaps);
++    virQEMUCapsFillDomainFeatureCCACaps(qemuCaps, domCaps);
+     virQEMUCapsFillDomainFeatureHypervCaps(qemuCaps, domCaps);
+     virQEMUCapsFillDomainDeviceCryptoCaps(qemuCaps, crypto);
+     virQEMUCapsFillDomainLaunchSecurity(qemuCaps, launchSecurity);
+diff --git a/src/qemu/qemu_capabilities.h b/src/qemu/qemu_capabilities.h
+index 1eb94f41..2f43f969 100644
+--- a/src/qemu/qemu_capabilities.h
++++ b/src/qemu/qemu_capabilities.h
+@@ -912,6 +912,9 @@ virQEMUCapsGetSEVCapabilities(virQEMUCaps *qemuCaps);
+ virSGXCapability *
+ virQEMUCapsGetSGXCapabilities(virQEMUCaps *qemuCaps);
+ 
++virCCACapability *
++virQEMUCapsGetCCACapabilities(virQEMUCaps *qemuCaps);
++
+ bool
+ virQEMUCapsGetKVMSupportsSecureGuest(virQEMUCaps *qemuCaps) G_NO_INLINE;
+ 
+-- 
+2.51.0
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -7,3 +7,8 @@ debian/Use-sensible-editor-by-default.patch
 deepin/0001-conf-qemu-add-libvirt-support-reuse-id-for-hygon-CSV.patch
 deepin/0002-conf-qemu-support-provide-inject-secret-for-Hygon-CS.patch
 deepin/0003-feat-deepin-add-sw64-support.patch
+
+# Support ARM CCA
+backport/0001-src-Add-ARM-CCA-support-in-qemu-driver-to-launch-VM.patch
+backport/0002-src-Add-ARM-CCA-support-in-domain-capabilities-comma.patch
+backport/0003-src-Add-ARM-CCA-support-in-domain-schema.patch


### PR DESCRIPTION
[ Feature description ]

Confidential computing changes the traditional trust model by reducing the amount of trust users must place in the compute infrastructure (for example, the OS or hypervisor). It runs workloads inside a hardware-backed trusted execution environment to protect data-in-use, preventing privileged software and hardware agents from observing or tampering with data and code. ARM’s Confidential Compute Architecture (CCA) is an architectural extension that provides confidential computing capabilities. Its main features include:
 *1. Introducing a confidential execution environment called Realm to protect
in-use data and code.
  2. Allowing any third-party developer to protect their VMs or applications.
  3. Supporting dynamic memory allocation.
  4. Supporting remote attestation.

Compared with the earlier TrustZone technology, CCA can provide security at the confidential-VM level and supports seamless migration of large applications. For more details, see ARM’s official page. [1]

The Host/KVM must manage Realm lifecycle, allocate and reclaim Realm resources, and schedule Realms via the Realm Management Interface (RMI). The kernel/KVM will need corresponding patches to support CCA.

[ Affected repositories ]
kernel, libvirt, QEMU.

[1]. https://www.arm.com/architecture/security-features/arm-confidential-compute-architecture

Link: https://gitee.com/opencloudos-stream/libvirt/pulls/22