### PR TITLE
fix: fix file conflict between libvirt-daemon-system and libvirt-daemon

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+libvirt (10.7.0+really9.10.0-1deepin7) unstable; urgency=medium
+
+  * Fix file conflict between libvirt-daemon-system and libvirt-daemon
+    for /etc/apparmor.d/usr.sbin.libvirtd.
+
+ -- lichenggang <lichenggang@uniontech.com>  Fri, 08 May 2026 10:17:51 +0800
+
 libvirt (10.7.0+really9.10.0-1deepin6) unstable; urgency=medium
 
   * Revert to previous upstream.

--- a/debian/control
+++ b/debian/control
@@ -357,6 +357,10 @@ Suggests:
  systemd,
  systemtap,
  zfsutils,
+Breaks:
+ libvirt-daemon (<< 10.7.0+really9.10.0-1~),
+Replaces:
+ libvirt-daemon (<< 10.7.0+really9.10.0-1~),
 Description: Libvirt daemon configuration files
  Libvirt is a C toolkit to interact with the virtualization capabilities
  of recent versions of Linux (and other OSes). The library aims at providing


### PR DESCRIPTION
Add Breaks and Replaces for libvirt-daemon in libvirt-daemon-system to resolve the dpkg error when installing libvirt-daemon-system: "trying to overwrite '/etc/apparmor.d/usr.sbin.libvirtd', also in libvirt-daemon" The apparmor profile was moved from libvirt-daemon (in 10.7.0-3deepin3) to libvirt-daemon-system during the revert to 9.10.0-based packaging, but the control file was missing the necessary Replaces declaration.

Log: Fix dpkg unpack error for /etc/apparmor.d/usr.sbin.libvirtd

Influence:
1. Install or upgrade libvirt-daemon-system without file conflict
2. Ensure smooth package transition from libvirt-daemon 10.7.0-3deepin3
3. Verify libvirt-daemon-system can replace old libvirt-daemon apparmor files

fix: 修复 libvirt-daemon-system 与 libvirt-daemon 之间的文件冲突

在 libvirt-daemon-system 中添加对 libvirt-daemon 的 Breaks 和 Replaces， 以解决安装 libvirt-daemon-system 时的 dpkg 错误：
"正试图覆盖 '/etc/apparmor.d/usr.sbin.libvirtd'，它同时被包含于软件包 libvirt-daemon" 在回退到基于 9.10.0 的打包结构时，apparmor 配置文件从 libvirt-daemon 移动到了 libvirt-daemon-system，但 control 文件缺少必要的 Replaces 声明。

Log: 修复 /etc/apparmor.d/usr.sbin.libvirtd 的 dpkg 解压错误

Influence:
1. 无文件冲突地安装或升级 libvirt-daemon-system
2. 确保从 libvirt-daemon 10.7.0-3deepin3 平滑过渡
3. 验证 libvirt-daemon-system 可以替换旧版 libvirt-daemon 的 apparmor 文件

repo: libvirt #master