### PR TITLE
fix: resolve file conflict between libvirt-daemon and libvirt-daemon-common during downgrade

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,20 @@
+libvirt (10.7.0+really9.10.0-1deepin17) unstable; urgency=medium
+
+  * Fix package file conflict between libvirt-daemon and libvirt-daemon-common
+    - Add Conflicts/Replaces on libvirt-daemon-common in libvirt-daemon
+    - During downgrade from 10.7.0-3deepin3, libvirt-daemon-common owns virt-ssh-helper
+    - libvirt-daemon (9.10.0) needs to reclaim this file from the removed package
+  * Fix build failure on OBS due to missing git
+    - Add -Dno_git=true to meson configuration in debian/rules
+    - OBS build environment lacks git, causing meson.build to fail at configure time
+    - The no_git option already exists upstream but was not being used
+  * Fix build failure with libssh >= 0.11 due to deprecated function
+    - ssh_channel_get_exit_status() is deprecated in libssh 0.11+
+    - Call the function once and store result in local variable
+    - Fixes -Werror=deprecated-declarations build error
+
+ -- lichenggang <lichenggang@uniontech.com>  Mon, 01 Jun 2026 10:00:00 +0800
+
 libvirt (10.7.0+really9.10.0-1deepin16) unstable; urgency=medium
 
   * Enable ACPI by default for LoongArch virt machines

--- a/debian/changelog
+++ b/debian/changelog
@@ -12,6 +12,9 @@ libvirt (10.7.0+really9.10.0-1deepin17) unstable; urgency=medium
     - ssh_channel_get_exit_status() is deprecated in libssh 0.11+
     - Call the function once and store result in local variable
     - Fixes -Werror=deprecated-declarations build error
+  * Fix sw64 cpu driver incompatible function pointer
+    - Remove extra virCPUFeaturePolicy parameter from virCPUsw64Update
+    - virCPUArchUpdate typedef expects 3 parameters, not 4
 
  -- lichenggang <lichenggang@uniontech.com>  Mon, 01 Jun 2026 10:00:00 +0800
 

--- a/debian/control
+++ b/debian/control
@@ -164,10 +164,12 @@ Enhances:
  xen,
 Breaks:
  libvirt-clients (<< 6.9.0-2~),
+ libvirt-daemon-common,
  libvirt-daemon-driver-lxc (<< 6.9.0-2~),
  libvirt-daemon-system (<< 6.9.0-3~),
  libvirt-sanlock (<< 6.9.0-2~),
 Replaces:
+ libvirt-daemon-common,
  libvirt-daemon-system (<< 6.9.0-3~),
 Description: Virtualization daemon
  Libvirt is a C toolkit to interact with the virtualization capabilities

--- a/debian/patches/fix-libssh-deprecated-exit-status.patch
+++ b/debian/patches/fix-libssh-deprecated-exit-status.patch
@@ -1,0 +1,63 @@
+From: lichenggang <lichenggang@uniontech.com>
+Date: Mon, 01 Jun 2026 18:30:00 +0800
+Subject: Fix deprecated ssh_channel_get_exit_status usage with libssh >= 0.11
+
+libssh 0.11+ marks ssh_channel_get_exit_status() as deprecated, and
+libvirt builds with -Werror, causing compilation to fail with:
+
+  error: 'ssh_channel_get_exit_status' is deprecated [-Werror=deprecated-declarations]
+
+Wrap the deprecated function call with
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+and store the result in a local variable to avoid redundant calls.
+
+Signed-off-by: lichenggang <lichenggang@uniontech.com>
+
+--- a/src/rpc/virnetlibsshsession.c
++++ b/src/rpc/virnetlibsshsession.c
+@@ -1179,12 +1179,19 @@ virNetLibsshChannelRead(virNetLibsshSession *sess,
+     }
+
+     if (ssh_channel_is_eof(sess->channel)) {
++        int exitStatus;
++
+  eof:
+-        if (ssh_channel_get_exit_status(sess->channel)) {
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
++        exitStatus = ssh_channel_get_exit_status(sess->channel);
++#pragma GCC diagnostic pop
++
++        if (exitStatus) {
+             virReportError(VIR_ERR_LIBSSH,
+                            _("Remote command terminated with non-zero code: %1$d"),
+-                           ssh_channel_get_exit_status(sess->channel));
+-            sess->channelCommandReturnValue = ssh_channel_get_exit_status(sess->channel);
++                           exitStatus);
++            sess->channelCommandReturnValue = exitStatus;
+             sess->state = VIR_NET_LIBSSH_STATE_ERROR_REMOTE;
+             virObjectUnlock(sess);
+             return -1;
+@@ -1227,12 +1234,19 @@ virNetLibsshChannelWrite(virNetLibsshSession *sess,
+     }
+
+     if (ssh_channel_is_eof(sess->channel)) {
+-        if (ssh_channel_get_exit_status(sess->channel)) {
++        int exitStatus;
++
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
++        exitStatus = ssh_channel_get_exit_status(sess->channel);
++#pragma GCC diagnostic pop
++
++        if (exitStatus) {
+             virReportError(VIR_ERR_LIBSSH,
+                            _("Remote program terminated with non-zero code: %1$d"),
+-                           ssh_channel_get_exit_status(sess->channel));
++                           exitStatus);
+             sess->state = VIR_NET_LIBSSH_STATE_ERROR_REMOTE;
+-            sess->channelCommandReturnValue = ssh_channel_get_exit_status(sess->channel);
++            sess->channelCommandReturnValue = exitStatus;
+
+             ret = -1;
+             goto cleanup;

--- a/debian/patches/fix-sw64-cpu-update-signature.patch
+++ b/debian/patches/fix-sw64-cpu-update-signature.patch
@@ -1,0 +1,24 @@
+From: lichenggang <lichenggang@uniontech.com>
+Date: Mon, 01 Jun 2026 18:42:16 +0800
+Subject: Fix incompatible sw64 CPU update function signature
+
+The virCPUsw64Update function had an extra virCPUFeaturePolicy parameter
+that doesn't exist in the virCPUArchUpdate typedef. This caused:
+
+  error: initialization from incompatible pointer type
+
+Remove the extra parameter to match the expected function signature.
+
+Signed-off-by: lichenggang <lichenggang@uniontech.com>
+
+--- a/src/cpu/cpu_sw64.c
++++ b/src/cpu/cpu_sw64.c
+@@ -56,8 +56,7 @@ virCPUsw64Compare(virCPUDef *host ATTRIB
+ static int
+ virCPUsw64Update(virCPUDef *guest,
+                  const virCPUDef *host,
+-                 bool relative ATTRIBUTE_UNUSED,
+-                 virCPUFeaturePolicy removedPolicy G_GNUC_UNUSED)
++                 bool relative ATTRIBUTE_UNUSED)
+ {
+     g_autoptr(virCPUDef) updated = NULL;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -6,6 +6,7 @@ deepin/0001-conf-qemu-add-libvirt-support-reuse-id-for-hygon-CSV.patch
 deepin/0002-conf-qemu-support-provide-inject-secret-for-Hygon-CS.patch
 deepin/add-custom-policy-for-deepin.patch
 deepin/0003-feat-deepin-add-sw64-support.patch
+fix-sw64-cpu-update-signature.patch
 backport/0001-src-Add-ARM-CCA-support-in-qemu-driver-to-launch-VM.patch
 backport/0002-src-Add-ARM-CCA-support-in-domain-capabilities-comma.patch
 backport/0003-src-Add-ARM-CCA-support-in-domain-schema.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -15,3 +15,4 @@ fix-firmware-descriptor-parsing.patch
 add-loongarch64-arch-support.patch
 fix-virtio-iommu-test-expected-output.patch
 enable-acpi-for-loongarch-virt.patch
+fix-libssh-deprecated-exit-status.patch

--- a/debian/rules
+++ b/debian/rules
@@ -146,6 +146,7 @@ DEB_CONFIGURE_EXTRA_ARGS := \
     -Dinitconfdir=/etc/default \
     -Dpackager="$(DEB_VENDOR)" \
     -Dpackager_version="$(DEB_VERSION)" \
+    -Dno_git=true \
     $(WITH_DAEMONS) \
     $(WITH_QEMU) \
     -Ddriver_remote=enabled \


### PR DESCRIPTION
## Summary

### 1. Package file conflict during downgrade
- Add `Conflicts`/`Replaces` on `libvirt-daemon-common` in `libvirt-daemon` package
- During downgrade from 10.7.0-3deepin3, `libvirt-daemon-common` owns `/usr/bin/virt-ssh-helper`

### 2. OBS build failure due to missing git
- Add `-Dno_git=true` to meson configuration in `debian/rules`

### 3. Build failure with libssh >= 0.11
- Wrap `ssh_channel_get_exit_status()` with `#pragma GCC diagnostic`
- Fixes `-Werror=deprecated-declarations`

### 4. sw64 CPU driver incompatible function pointer
- Remove extra `virCPUFeaturePolicy` parameter from `virCPUsw64Update`
- Fixes `-Werror=incompatible-pointer-types` on loong64

## Files changed
- `debian/control` - Conflicts/Replaces on libvirt-daemon-common
- `debian/rules` - -Dno_git=true
- `debian/patches/fix-libssh-deprecated-exit-status.patch` - New patch
- `debian/patches/fix-sw64-cpu-update-signature.patch` - New patch
- `debian/patches/series` - Register new patches
- `debian/changelog` - Version 10.7.0+really9.10.0-1deepin17