### PR TITLE
Fix dependency issues from 9.10.0-1deepin6

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,25 @@
+libvirt (10.7.0+really9.10.0-1deepin20) unstable; urgency=medium
+
+  * Fix dependency issues:
+    - Declare Breaks & Replaces against libvirt-common
+    - Declare Breaks & Replaces against libvirt-daemon-common
+    - Declare Breaks & Replaces against libvirt-daemon-driver-interface
+    - Declare Breaks & Replaces against libvirt-daemon-driver-network
+    - Declare Breaks & Replaces against libvirt-daemon-driver-nodedev
+    - Declare Breaks & Replaces against libvirt-daemon-driver-nwfilter
+    - Declare Breaks & Replaces against libvirt-daemon-driver-secret
+    - Declare Breaks & Replaces against libvirt-daemon-driver-storage-disk
+    - Declare Breaks & Replaces against libvirt-daemon-driver-storage-iscsi
+    - Declare Breaks & Replaces against libvirt-daemon-driver-storage-logical
+    - Declare Breaks & Replaces against libvirt-daemon-driver-storage-mpath
+    - Declare Breaks & Replaces against libvirt-daemon-driver-storage-scsi
+    - Declare Breaks & Replaces against libvirt-daemon-driver-storage
+    - Declare Breaks & Replaces against libvirt-daemon-lock
+    - Declare Breaks & Replaces against libvirt-daemon-log
+    - Declare Breaks & Replaces against libvirt-daemon-plugin-lockd
+
+ -- Tianyu Chen <sweetyfish@deepin.org>  Tue, 16 Jun 2026 10:02:07 +0800
+
 libvirt (10.7.0+really9.10.0-1deepin19) unstable; urgency=medium
 
   * Fix file conflict between libvirt-clients and libvirt-daemon-common
@@ -156,7 +178,6 @@ libvirt (10.7.0+really9.10.0-1deepin7) unstable; urgency=medium
 libvirt (10.7.0+really9.10.0-1deepin6) unstable; urgency=medium
 
   * Revert to previous upstream.
-  
 
  -- lichenggang <lichenggang@deepin.org>  Thu, 30 Apr 2026 17:36:31 +0800
 

--- a/debian/control
+++ b/debian/control
@@ -167,14 +167,40 @@ Enhances:
  xen,
 Breaks:
  libvirt-clients (<< 6.9.0-2~),
- libvirt-daemon-common,
+ libvirt-daemon-common (<< 10.7.0+really9.10.0-1deepin6),
  libvirt-daemon-driver-lxc (<< 6.9.0-2~),
- libvirt-daemon-driver-network (<< 10.7.0+really9.10.0-1deepin17),
+ libvirt-daemon-driver-interface (<< 10.7.0+really9.10.0-1deepin6),
+ libvirt-daemon-driver-network (<< 10.7.0+really9.10.0-1deepin6),
+ libvirt-daemon-driver-nodedev (<< 10.7.0+really9.10.0-1deepin6),
+ libvirt-daemon-driver-nwfilter (<< 10.7.0+really9.10.0-1deepin6),
+ libvirt-daemon-driver-secret (<< 10.7.0+really9.10.0-1deepin6),
+ libvirt-daemon-driver-storage (<< 10.7.0+really9.10.0-1deepin6),
+ libvirt-daemon-driver-storage-disk (<< 10.7.0+really9.10.0-1deepin6),
+ libvirt-daemon-driver-storage-iscsi (<< 10.7.0+really9.10.0-1deepin6),
+ libvirt-daemon-driver-storage-logical (<< 10.7.0+really9.10.0-1deepin6),
+ libvirt-daemon-driver-storage-mpath (<< 10.7.0+really9.10.0-1deepin6),
+ libvirt-daemon-driver-storage-scsi (<< 10.7.0+really9.10.0-1deepin6),
+ libvirt-daemon-lock (<< 10.7.0+really9.10.0-1deepin6),
+ libvirt-daemon-log (<< 10.7.0+really9.10.0-1deepin6),
+ libvirt-daemon-plugin-lockd (<< 10.7.0+really9.10.0-1deepin6),
  libvirt-daemon-system (<< 6.9.0-3~),
  libvirt-sanlock (<< 6.9.0-2~),
 Replaces:
- libvirt-daemon-common,
- libvirt-daemon-driver-network (<< 10.7.0+really9.10.0-1deepin17),
+ libvirt-daemon-common (<< 10.7.0+really9.10.0-1deepin6),
+ libvirt-daemon-driver-interface (<< 10.7.0+really9.10.0-1deepin6),
+ libvirt-daemon-driver-network (<< 10.7.0+really9.10.0-1deepin6),
+ libvirt-daemon-driver-nodedev (<< 10.7.0+really9.10.0-1deepin6),
+ libvirt-daemon-driver-nwfilter (<< 10.7.0+really9.10.0-1deepin6),
+ libvirt-daemon-driver-secret (<< 10.7.0+really9.10.0-1deepin6),
+ libvirt-daemon-driver-storage (<< 10.7.0+really9.10.0-1deepin6),
+ libvirt-daemon-driver-storage-disk (<< 10.7.0+really9.10.0-1deepin6),
+ libvirt-daemon-driver-storage-iscsi (<< 10.7.0+really9.10.0-1deepin6),
+ libvirt-daemon-driver-storage-logical (<< 10.7.0+really9.10.0-1deepin6),
+ libvirt-daemon-driver-storage-mpath (<< 10.7.0+really9.10.0-1deepin6),
+ libvirt-daemon-driver-storage-scsi (<< 10.7.0+really9.10.0-1deepin6),
+ libvirt-daemon-lock (<< 10.7.0+really9.10.0-1deepin6),
+ libvirt-daemon-log (<< 10.7.0+really9.10.0-1deepin6),
+ libvirt-daemon-plugin-lockd (<< 10.7.0+really9.10.0-1deepin6),
  libvirt-daemon-system (<< 6.9.0-3~),
 Description: Virtualization daemon
  Libvirt is a C toolkit to interact with the virtualization capabilities
@@ -369,11 +395,11 @@ Suggests:
 Breaks:
  libvirt-common (<< 10.7.0+really9.10.0-1deepin6),
  libvirt-daemon-common,
- libvirt-daemon-driver-network (<< 10.7.0+really9.10.0-1deepin17),
+ libvirt-daemon-driver-network (<< 10.7.0+really9.10.0-1deepin6),
 Replaces:
  libvirt-common (<< 10.7.0+really9.10.0-1deepin6),
  libvirt-daemon-common,
- libvirt-daemon-driver-network (<< 10.7.0+really9.10.0-1deepin17),
+ libvirt-daemon-driver-network (<< 10.7.0+really9.10.0-1deepin6),
 Description: Libvirt daemon configuration files
  Libvirt is a C toolkit to interact with the virtualization capabilities
  of recent versions of Linux (and other OSes). The library aims at providing
@@ -412,6 +438,12 @@ Depends:
  libvirt0 (<< ${source:Version}.1~),
  libvirt0 (>= ${source:Version}),
  ${misc:Depends},
+Breaks:
+ libvirt-daemon-common (<< 10.7.0+really9.10.0-1deepin6),
+ libvirt-daemon-log (<< 10.7.0+really9.10.0-1deepin6),
+Replaces:
+ libvirt-daemon-common (<< 10.7.0+really9.10.0-1deepin6),
+ libvirt-daemon-log (<< 10.7.0+really9.10.0-1deepin6),
 Description: Libvirt daemon configuration files (sysv)
  Libvirt is a C toolkit to interact with the virtualization capabilities
  of recent versions of Linux (and other OSes). The library aims at providing


### PR DESCRIPTION
* Declare Breaks & Replaces against libvirt-common
* Declare Breaks & Replaces against libvirt-daemon-common
* Declare Breaks & Replaces against libvirt-daemon-driver-interface
* Declare Breaks & Replaces against libvirt-daemon-driver-network
* Declare Breaks & Replaces against libvirt-daemon-driver-nodedev
* Declare Breaks & Replaces against libvirt-daemon-driver-nwfilter
* Declare Breaks & Replaces against libvirt-daemon-driver-secret
* Declare Breaks & Replaces against libvirt-daemon-driver-storage-disk
* Declare Breaks & Replaces against libvirt-daemon-driver-storage-iscsi
* Declare Breaks & Replaces against libvirt-daemon-driver-storage-logical
* Declare Breaks & Replaces against libvirt-daemon-driver-storage-mpath
* Declare Breaks & Replaces against libvirt-daemon-driver-storage-scsi
* Declare Breaks & Replaces against libvirt-daemon-driver-storage
* Declare Breaks & Replaces against libvirt-daemon-lock
* Declare Breaks & Replaces against libvirt-daemon-log
* Declare Breaks & Replaces against libvirt-daemon-plugin-lockd
