### PR TITLE
fix(libvirt-guests): redirect service output to journal to suppress s…

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+libvirt (10.7.0+really9.10.0-1deepin21) unstable; urgency=medium
+
+  * Redirect libvirt-guests service output to journal to suppress console 
+  * error messages during shutdown
+
+ -- xinpeng.wang <wangxinpeng@uniontech.com>  Mon, 22 Jun 2026 15:18:41 +0800
+
 libvirt (10.7.0+really9.10.0-1deepin20) unstable; urgency=medium
 
   * Fix dependency issues:

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -17,3 +17,4 @@ add-loongarch64-arch-support.patch
 fix-virtio-iommu-test-expected-output.patch
 enable-acpi-for-loongarch-virt.patch
 fix-libssh-deprecated-exit-status.patch
+uniontech-remove-libvirt-guests-log.patch

--- a/debian/patches/uniontech-remove-libvirt-guests-log.patch
+++ b/debian/patches/uniontech-remove-libvirt-guests-log.patch
@@ -1,0 +1,13 @@
+Index: deepin-libvirt/tools/libvirt-guests.service.in
+===================================================================
+--- deepin-libvirt.orig/tools/libvirt-guests.service.in
++++ deepin-libvirt/tools/libvirt-guests.service.in
+@@ -23,6 +23,8 @@ Type=oneshot
+ RemainAfterExit=yes
+ StandardOutput=journal+console
+ TimeoutStopSec=0
++StandardOutput=journal
++StandardError=journal
+ 
+ [Install]
+ WantedBy=multi-user.target


### PR DESCRIPTION
…hutdown

error messages

The libvirt-guests service prints "Can't connect to default. Skipping." to the console when shutting down if libvirtd is already stopped. This error message appears on the screen during system shutdown, disturbing the user experience.

Change StandardOutput and StandardError from "journal+console" to "journal" to suppress console output while still keeping logs available in the system journal for debugging purposes.

This ensures a clean shutdown experience without unnecessary error messages appearing on the console.

修复(libvirt-guests)：将服务输出重定向到 journal，抑制关机时的错误打印

当 libvirtd 在关机时已提前停止，libvirt-guests 服务会在控制台打印
"Can't connect to default. Skipping." 错误信息，影响关机体验。

将 StandardOutput 和 StandardError 从 "journal+console" 改为 "journal"， 在保留日志供调试的同时，屏蔽控制台输出，确保关机过程干净无干扰。
Bug: 362087